### PR TITLE
CONJ-157 Fix the executeBatch return value when rewriteBatchedStateme…

### DIFF
--- a/src/test/java/org/mariadb/jdbc/MultiTest.java
+++ b/src/test/java/org/mariadb/jdbc/MultiTest.java
@@ -27,8 +27,10 @@ public class MultiTest extends BaseTest {
         st.executeUpdate("drop table if exists t1");
         st.executeUpdate("drop table if exists t2");
         st.executeUpdate("drop table if exists t3");
+        st.executeUpdate("drop table if exists reWriteDuplicateTestTable");
         st.executeUpdate("create table t1(id int, test varchar(100))");
         st.executeUpdate("create table t2(id int, test varchar(100))");
+        st.executeUpdate("create table reWriteDuplicateTestTable(id int, name varchar(100), PRIMARY KEY (`id`))");
         st.executeUpdate("create table t3(message text)");
         st.execute("insert into t1 values(1,'a'),(2,'a')");
         st.execute("insert into t2 values(1,'a'),(2,'a')");
@@ -42,6 +44,7 @@ public class MultiTest extends BaseTest {
             st.executeUpdate("drop table if exists t1");
             st.executeUpdate("drop table if exists t2");
             st.executeUpdate("drop table if exists t3");
+            st.executeUpdate("drop table if EXISTS reWriteDuplicateTestTable");
         } catch (Exception e) {
             // eat
         }
@@ -147,92 +150,122 @@ public class MultiTest extends BaseTest {
         rs.close();
         assertEquals(1, cnt);
    }
-   
-   
-   /**
-    * CONJ-99: rewriteBatchedStatements parameter.
-    * @throws SQLException
-    */
-   @Test
-   public void rewriteBatchedStatementsInsertTest() throws SQLException  {
-	   // set the rewrite batch statements parameter
-	   Properties props = new Properties();
-	   props.setProperty("rewriteBatchedStatements", "true");
-	   connection.setClientInfo(props);
-	   
-       int cycles = 3000;
-       PreparedStatement preparedStatement = prepareStatementBatch(cycles);
-       int[] updateCounts = preparedStatement.executeBatch();
-       int totalUpdates = 0;
-       for (int count=0; count<updateCounts.length; count++) {
-    	   assertTrue(updateCounts[count] > 0);
-    	   totalUpdates += updateCounts[count];
-       }
-       assertEquals(cycles, totalUpdates);
-       connection.createStatement().execute("TRUNCATE t1");
-       Statement statement = connection.createStatement();
-       for (int i = 0; i < cycles; i++) {
-           statement.addBatch("INSERT INTO t1 VALUES (" + i + ", 'testValue" + i + "')");
-       }
-       updateCounts = statement.executeBatch();
-       totalUpdates = 0;
-       for (int count=0; count<updateCounts.length; count++) {
-    	   assertTrue(updateCounts[count] > 0);
-    	   totalUpdates += updateCounts[count];
-       }
-       assertEquals(cycles, totalUpdates);
-   }
-   
-   /**
+
+
+    /**
+     * CONJ-99: rewriteBatchedStatements parameter.
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void rewriteBatchedStatementsDisabledInsertionTest() throws SQLException {
+        verifyInsertBehaviorBasedOnRewriteBatchedStatements(Boolean.FALSE, 3000);
+    }
+
+    @Test
+    public void rewriteBatchedStatementsEnabledInsertionTest() throws SQLException {
+        //On batch mode, single insert query will be sent to MariaDB server.
+        verifyInsertBehaviorBasedOnRewriteBatchedStatements(Boolean.TRUE, 1);
+    }
+
+    private void verifyInsertBehaviorBasedOnRewriteBatchedStatements(Boolean rewriteBatchedStatements, int totalInsertCommands) throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("rewriteBatchedStatements", rewriteBatchedStatements.toString());
+        Connection tmpConnection = openNewConnection(connURI, props);
+        try {
+            verifyInsertCount(tmpConnection, 0);
+            int cycles = 3000;
+            tmpConnection.createStatement().execute("TRUNCATE t1");
+            Statement statement = tmpConnection.createStatement();
+            for (int i = 0; i < cycles; i++) {
+                statement.addBatch("INSERT INTO t1 VALUES (" + i + ", 'testValue" + i + "')");
+            }
+            int[] updateCounts = statement.executeBatch();
+            assertEquals(cycles, updateCounts.length);
+            int totalUpdates = 0;
+            for (int count = 0; count < updateCounts.length; count++) {
+                assertEquals(1, updateCounts[count]);
+                totalUpdates += updateCounts[count];
+            }
+            assertEquals(cycles, totalUpdates);
+            verifyInsertCount(tmpConnection, totalInsertCommands);
+        } finally {
+            tmpConnection.close();
+        }
+    }
+
+    private void verifyInsertCount(Connection tmpConnection, int insertCount) throws SQLException {
+        assertEquals(insertCount, retrieveSessionVariableFromServer(tmpConnection, "Com_insert"));
+    }
+
+    private int retrieveSessionVariableFromServer(Connection tmpConnection, String variable) throws SQLException {
+        Statement statement = tmpConnection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SHOW STATUS LIKE '" + variable + "'");
+        try {
+            if (resultSet.next()) {
+                return resultSet.getInt(2);
+            }
+        } finally {
+            resultSet.close();
+        }
+        throw new RuntimeException("Unable to retrieve, variable value from Server " + variable);
+    }
+
+    /**
     * CONJ-142: Using a semicolon in a string with "rewriteBatchedStatements=true" fails
     * @throws SQLException
     */
    @Test
-   public void rewriteBatchedStatementsSemicolon() throws SQLException  {
-	   // set the rewrite batch statements parameter
-	   Properties props = new Properties();
-	   props.setProperty("rewriteBatchedStatements", "true");
-	   setConnection(props);
-       
-	   connection.createStatement().execute("TRUNCATE t3");
-   
-       PreparedStatement sqlInsert = connection.prepareStatement("INSERT INTO t3 (message) VALUES (?)");
-       sqlInsert.setString(1, "aa");
-       sqlInsert.addBatch();
-       sqlInsert.setString(1, "b;b");
-       sqlInsert.addBatch();
-       sqlInsert.setString(1, ";ccccccc");
-       sqlInsert.addBatch();
-       sqlInsert.setString(1, "ddddddddddddddd;");
-       sqlInsert.addBatch();
-       sqlInsert.setString(1, ";eeeeeee;;eeeeeeeeee;eeeeeeeeee;");
-       sqlInsert.addBatch();
-       int[] updateCounts = sqlInsert.executeBatch();
-       
-       // rewrite should be ok, so the above should be executed in 1 command updating 5 rows
-       Assert.assertEquals(1, updateCounts.length);
-       Assert.assertEquals(5, updateCounts[0]);
-       
-       connection.commit();
-       
-       // Test for multiple statements which isn't allowed. rewrite shouldn't work
-       sqlInsert = connection.prepareStatement("INSERT INTO t3 (message) VALUES (?); INSERT INTO t3 (message) VALUES ('multiple')");
-       sqlInsert.setString(1, "aa");
-       sqlInsert.addBatch();
-       sqlInsert.setString(1, "b;b");
-       sqlInsert.addBatch();
-       updateCounts = sqlInsert.executeBatch();
+   public void rewriteBatchedStatementsSemicolon() throws SQLException {
+       // set the rewrite batch statements parameter
+       Properties props = new Properties();
+       props.setProperty("rewriteBatchedStatements", "true");
+       Connection tmpConnection = openNewConnection(connURI, props);
+       try {
+           tmpConnection.createStatement().execute("TRUNCATE t3");
 
-       // rewrite should NOT be possible. Therefore there should be 2 commands updating 1 row each.
-       Assert.assertEquals(2, updateCounts.length);
-       Assert.assertEquals(1, updateCounts[0]);
-       Assert.assertEquals(1, updateCounts[1]);
-       
-       connection.commit();
+           PreparedStatement sqlInsert = tmpConnection.prepareStatement("INSERT INTO t3 (message) VALUES (?)");
+           sqlInsert.setString(1, "aa");
+           sqlInsert.addBatch();
+           sqlInsert.setString(1, "b;b");
+           sqlInsert.addBatch();
+           sqlInsert.setString(1, ";ccccccc");
+           sqlInsert.addBatch();
+           sqlInsert.setString(1, "ddddddddddddddd;");
+           sqlInsert.addBatch();
+           sqlInsert.setString(1, ";eeeeeee;;eeeeeeeeee;eeeeeeeeee;");
+           sqlInsert.addBatch();
+           int[] updateCounts = sqlInsert.executeBatch();
+
+           // rewrite should be ok, so the above should be executed in 1 command updating 5 rows
+           Assert.assertEquals(5, updateCounts.length);
+           for (int i = 0; i < updateCounts.length; i++) {
+               Assert.assertEquals(1, updateCounts[i]);
+           }
+
+           tmpConnection.commit();
+           verifyInsertCount(tmpConnection, 1);
+           // Test for multiple statements which isn't allowed. rewrite shouldn't work
+           sqlInsert = tmpConnection.prepareStatement("INSERT INTO t3 (message) VALUES (?); INSERT INTO t3 (message) VALUES ('multiple')");
+           sqlInsert.setString(1, "aa");
+           sqlInsert.addBatch();
+           sqlInsert.setString(1, "b;b");
+           sqlInsert.addBatch();
+           updateCounts = sqlInsert.executeBatch();
+
+           // rewrite should NOT be possible. Therefore there should be 2 commands updating 1 row each.
+           Assert.assertEquals(2, updateCounts.length);
+           Assert.assertEquals(1, updateCounts[0]);
+           Assert.assertEquals(1, updateCounts[1]);
+           verifyInsertCount(tmpConnection, 5);
+           tmpConnection.commit();
+       }finally {
+           tmpConnection.close();
+       }
    }
-   
-   private PreparedStatement prepareStatementBatch(int size) throws SQLException {
-	   PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO t1 VALUES (?, ?)");
+
+   private PreparedStatement prepareStatementBatch(Connection tmpConnection, int size) throws SQLException {
+	   PreparedStatement preparedStatement = tmpConnection.prepareStatement("INSERT INTO t1 VALUES (?, ?)");
        for (int i = 0; i < size; i++) {
            preparedStatement.setInt(1, i);
            preparedStatement.setString(2, "testValue" + i);
@@ -240,7 +273,7 @@ public class MultiTest extends BaseTest {
        }
 	return preparedStatement;
    }
-   
+
    /**
     * CONJ-99: rewriteBatchedStatements parameter.
     * @throws SQLException
@@ -250,24 +283,61 @@ public class MultiTest extends BaseTest {
 	   // set the rewrite batch statements parameter
 	   Properties props = new Properties();
 	   props.setProperty("rewriteBatchedStatements", "true");
-	   connection.setClientInfo(props);
-	   
-	   connection.createStatement().execute("TRUNCATE t1");
-       int cycles = 1000;
-	   prepareStatementBatch(cycles).executeBatch();  // populate the table
-       PreparedStatement preparedStatement = connection.prepareStatement("UPDATE t1 SET test = ? WHERE id = ?");
-       for (int i = 0; i < cycles; i++) {
-           preparedStatement.setString(1, "updated testValue" + i);
-           preparedStatement.setInt(2, i);
-           preparedStatement.addBatch();    
+       Connection tmpConnection = openNewConnection(connURI, props);
+       try {
+           tmpConnection.setClientInfo(props);
+           verifyUpdateCount(tmpConnection, 0);
+           tmpConnection.createStatement().execute("TRUNCATE t1");
+           int cycles = 1000;
+           prepareStatementBatch(tmpConnection, cycles).executeBatch();  // populate the table
+           PreparedStatement preparedStatement = tmpConnection.prepareStatement("UPDATE t1 SET test = ? WHERE id = ?");
+           for (int i = 0; i < cycles; i++) {
+               preparedStatement.setString(1, "updated testValue" + i);
+               preparedStatement.setInt(2, i);
+               preparedStatement.addBatch();
+           }
+           int[] updateCounts = preparedStatement.executeBatch();
+           assertEquals(cycles, updateCounts.length);
+           int totalUpdates = 0;
+           for (int count = 0; count < updateCounts.length; count++) {
+               assertEquals(1, updateCounts[count]);
+               totalUpdates += updateCounts[count];
+           }
+           verifyUpdateCount(tmpConnection, cycles);
+           assertEquals(cycles, totalUpdates);
+       } finally {
+           tmpConnection.close();
        }
-       int[] updateCounts = preparedStatement.executeBatch();
-       int totalUpdates = 0;
-       for (int count=0; count<updateCounts.length; count++) {
-    	   assertTrue(updateCounts[count] > 0);
-    	   totalUpdates += updateCounts[count];
-       }
-       assertEquals(cycles, totalUpdates);
    }
-   
+
+    @Test
+    public void rewriteBatchedStatementsInsertWithDuplicateRecordsTest() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("rewriteBatchedStatements", "true");
+        Connection tmpConnection = openNewConnection(connURI, props);
+        try {
+            verifyInsertCount(tmpConnection, 0);
+            tmpConnection.createStatement().execute("TRUNCATE reWriteDuplicateTestTable");
+            Statement statement = tmpConnection.createStatement();
+            for (int i = 0; i < 100; i++) {
+                int newId = i % 20; //to create duplicate id's
+                String roleTxt = "'VAMPIRE" + newId;
+                statement.addBatch("INSERT IGNORE  INTO reWriteDuplicateTestTable VALUES (" + newId + ", " + roleTxt + "')");
+            }
+            int[] updateCounts = statement.executeBatch();
+            assertEquals(100, updateCounts.length);
+
+            for (int i = 0; i < updateCounts.length; i++) {
+                assertEquals(MySQLStatement.SUCCESS_NO_INFO, updateCounts[i]);
+            }
+            verifyInsertCount(tmpConnection, 1);
+            verifyUpdateCount(tmpConnection, 0);
+        } finally {
+            tmpConnection.close();
+        }
+    }
+
+    private void verifyUpdateCount(Connection tmpConnection, int updateCount) throws SQLException {
+        assertEquals(updateCount, retrieveSessionVariableFromServer(tmpConnection, "Com_update"));
+    }
 }


### PR DESCRIPTION
…nts are enabled

The batch insertion feature implemented in MariaDB connector 1.1.8(requirement CONJ-99) has broken the hibernate code. when rewriteBatchedStatements enabled, MariaDB connector will rewrite multiple insert commands(INSERT INTO table_xyz VALUES(0, 'val0'), INSERT INTO table_xyz VALUES(1, 'val1')) to a long insert(INSERT INTO table_xyz VALUES(0, 'val0'), (1, 'val1')).

The problem is with the return value(array returned from MariaDB connector) of executeBatch, whose size is always 1. But Hibernate expects the result array size same as the batch size. This is valid from hibernate perspective as it expects according to the API standard.

The proposal is to correct the implementation in MariaDB client based on the standard.

Fix:
Correcting the implementation to return the result set(array) as the size of commands included in the batch. The value of individual entries in the result set will be either 1 or SUCCESS_NO_INFO. if the updatecount received from MariaDB server is same as batch size then 1 otherwise SUCCESS_NO_INFO.

Note: This behavior is applicable only when rewriteBatchedStatements enabled!.