### PR TITLE
Re-Add Travis image, but only for master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 MariaDB Connector/J is used to connect applications developed in Java to MariaDB and MySQL databases. MariaDB Connector/J is LGPL licensed.
 
 Tracker link <a href="https://mariadb.atlassian.net/projects/CONJ/issues/">https://mariadb.atlassian.net/projects/CONJ/issues/</a>
-<!--
+
 ## Status
-[![Build Status](https://travis-ci.org/MariaDB/mariadb-connector-j.svg)](https://travis-ci.org/MariaDB/mariadb-connector-j)
--->
+[![Build Status](https://travis-ci.org/MariaDB/mariadb-connector-j.svg?branch=master)](https://travis-ci.org/MariaDB/mariadb-connector-j)
+
 ## Obtaining the driver
 The driver (jar) can be downloaded from [mariadb connector download](https://mariadb.com/products/connectors-plugins)
 


### PR DESCRIPTION
Travis-ci image was removed because it was wrongly reporting this
project as failing. It will no longer be the case with this commit
because I have added ?branch=master te be sure the picture shows the
status of the master branch.

This reverts commit c60749c2491b04b29f0ac680f8b72f04a1f86a76.