### PR TITLE
Add plugin support

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -430,7 +430,8 @@ public class MySQLProtocol {
                    MySQLServerCapabilities.SECURE_CONNECTION|
                    MySQLServerCapabilities.LOCAL_FILES|
                    MySQLServerCapabilities.MULTI_RESULTS|
-                   MySQLServerCapabilities.FOUND_ROWS;
+                   MySQLServerCapabilities.FOUND_ROWS|
+                   MySQLServerCapabilities.PLUGIN_AUTH;
 
 
 
@@ -483,7 +484,9 @@ public class MySQLProtocol {
                    capabilities,
                    decideLanguage(),
                    greetingPacket.getSeed(),
-                   packetSeq);
+                   packetSeq,
+                   new byte[0],
+                   greetingPacket.getPluginName());
            cap.send(writer);
            log.finest("Sending auth packet");
 

--- a/src/main/java/org/mariadb/jdbc/internal/mysql/packet/commands/MySQLClientAuthPacket.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/packet/commands/MySQLClientAuthPacket.java
@@ -91,14 +91,18 @@ public class MySQLClientAuthPacket implements CommandPacket {
                                  final String database,
                                  final int serverCapabilities,
                                  final byte serverLanguage,
-                                 final byte[] seed, byte packetSeq) {
+                                 final byte[] seed,
+                                 byte packetSeq,
+                                 byte[] authData,
+                                 String plugin) {
         this.packetSeq = packetSeq;
         writeBuffer = new WriteBuffer();
-        final byte[] scrambledPassword;
-        try {
-            scrambledPassword = Utils.encryptPassword(password, seed);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("Could not use SHA-1, failing", e);
+        if (plugin.equals("mysql_native_password")) {
+            try {
+                authData = Utils.encryptPassword(password, seed);
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException("Could not use SHA-1, failing", e);
+            }
         }
 
         writeBuffer.writeInt(serverCapabilities).
@@ -106,12 +110,20 @@ public class MySQLClientAuthPacket implements CommandPacket {
                 writeByte(serverLanguage). //1
                 writeBytes((byte) 0, 23).    //23
                 writeString(username).     //strlen username
-                writeByte((byte) 0).        //1
-                writeByte((byte) scrambledPassword.length).
-                writeByteArray(scrambledPassword); //scrambledPassword.length
+                writeByte((byte) 0);        //1
+
+        if ((serverCapabilities & MySQLServerCapabilities.SECURE_CONNECTION) != 0) {
+            writeBuffer.writeByte((byte) authData.length).
+                writeByteArray(authData);
+        } else {
+            writeBuffer.writeByte((byte) 0);
+        }
 
         if ((serverCapabilities & MySQLServerCapabilities.CONNECT_WITH_DB) != 0) {
             writeBuffer.writeString(database).writeByte((byte) 0);
+        }
+        if ((serverCapabilities & MySQLServerCapabilities.PLUGIN_AUTH) != 0) {
+            writeBuffer.writeString(plugin).writeByte((byte) 0);
         }
     }
 


### PR DESCRIPTION
Adds MySQLServerCapabilities.PLUGIN_AUTH to the default capabilities of
the client.

Correctly decodes server announced capabilities by reading the second
short value representing the high values.

Parses out the plugin name from the server protocol.

Correctly produces a MySQLClientAuthPacket based on server capabilities
and extends this to potentially allow for other client authentication
plugins in future.