### PR TITLE
getProtocol() scope, LOCAL INFILE option, SSL fix, and SSL Cert Enhancement

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/common/DefaultOptions.java
+++ b/src/main/java/org/mariadb/jdbc/internal/common/DefaultOptions.java
@@ -118,6 +118,11 @@ public enum DefaultOptions {
     USE_OLD_ALIAS_METADATA_BEHAVIOR("useOldAliasMetadataBehavior", Boolean.FALSE, "1.1.9"),
 
     /**
+     *  If set to 'false', exception thrown during LOCAL INFILE if no InputStream has already been set.
+     */
+    ALLOW_LOCAL_INFILE("allowLocalInfile", Boolean.TRUE, "1.2.1"),
+
+    /**
      * var=value pairs separated by comma, mysql session variables, set upon establishing successful connection
      */
     SESSION_VARIABLES("sessionVariables", "1.1.0"),

--- a/src/main/java/org/mariadb/jdbc/internal/common/Options.java
+++ b/src/main/java/org/mariadb/jdbc/internal/common/Options.java
@@ -84,6 +84,7 @@ public class Options {
     public boolean nullCatalogMeansCurrent;
     public boolean dumpQueriesOnException;
     public boolean useOldAliasMetadataBehavior;
+    public boolean allowLocalInfile;
 
     //HA options
     public boolean autoReconnect;
@@ -129,6 +130,7 @@ public class Options {
                 ", nullCatalogMeansCurrent=" + nullCatalogMeansCurrent +
                 ", dumpQueriesOnException=" + dumpQueriesOnException +
                 ", useOldAliasMetadataBehavior=" + useOldAliasMetadataBehavior +
+                ", allowLocalInfile=" + allowLocalInfile +
                 ", autoReconnect=" + autoReconnect +
                 ", failOnReadOnly=" + failOnReadOnly +
                 ", secondsBeforeRetryMaster=" + secondsBeforeRetryMaster +

--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -938,6 +938,12 @@ public class MySQLProtocol implements Protocol {
 
                 InputStream is;
                 if (localInfileInputStream == null) {
+                    if (!getJdbcUrl().getOptions().allowLocalInfile) {
+                      throw new QueryException(
+                          "Usage of LOCAL INFILE is disabled. To use it enable it via the connection property allowLocalInfile=true",
+                          -1,
+                          SQLExceptionMapper.SQLStates.FEATURE_NOT_SUPPORTED.getSqlState());
+                    }
                     LocalInfilePacket localInfilePacket = (LocalInfilePacket) resultPacket;
                     if (log.isTraceEnabled()) log.trace("sending local file " + localInfilePacket.getFileName());
                     String localInfile = localInfilePacket.getFileName();

--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -341,7 +341,7 @@ public class MySQLProtocol implements Protocol {
 
                 SSLSocketFactory f = getSSLSocketFactory(jdbcUrl.getOptions().trustServerCertificate);
                 SSLSocket sslSocket = (SSLSocket)f.createSocket(socket,
-                        socket.getInetAddress().getHostAddress(),  socket.getPort(),  false);
+                        socket.getInetAddress().getHostAddress(),  socket.getPort(), true);
 
                 sslSocket.setEnabledProtocols(new String [] {"TLSv1"});
                 sslSocket.setUseClientMode(true);

--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -82,6 +82,7 @@ import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -113,7 +114,7 @@ class MyX509TrustManager implements X509TrustManager {
         }
 
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        X509Certificate ca = (X509Certificate) cf.generateCertificate(inStream);
+        Collection<? extends Certificate> caList = cf.generateCertificates(inStream);
         inStream.close();
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         try {
@@ -122,7 +123,9 @@ class MyX509TrustManager implements X509TrustManager {
         } catch (Exception e) {
 
         }
-        ks.setCertificateEntry(UUID.randomUUID().toString(), ca);
+        for(Certificate ca : caList) {
+            ks.setCertificateEntry(UUID.randomUUID().toString(), ca);
+        }
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         tmf.init(ks);
         for(TrustManager tm : tmf.getTrustManagers()) {

--- a/src/test/java/org/mariadb/jdbc/LocalInfileDisableTest.java
+++ b/src/test/java/org/mariadb/jdbc/LocalInfileDisableTest.java
@@ -1,0 +1,41 @@
+package org.mariadb.jdbc;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LocalInfileDisableTest extends BaseTest {
+  @Before
+  public void setup() throws SQLException {
+    setConnection("&allowLocalInfile=false");
+    Statement stmt = connection.createStatement();
+    stmt.executeUpdate("DROP TABLE IF EXISTS t");
+    stmt.executeUpdate("CREATE TABLE t(id int, test varchar(100))");
+    stmt.close();
+  }
+
+  @Test
+  public void testLocalInfileWithoutInputStream() throws SQLException {
+    Statement stmt = null;
+    Exception ex = null;
+    try {
+      stmt = connection.createStatement();
+      stmt.executeUpdate("LOAD DATA LOCAL INFILE 'dummy.tsv' INTO TABLE t (id, test)");
+    } catch (Exception e) {
+      ex = e;
+    } finally {
+      try {
+        stmt.close();
+      } catch (Exception ignore) {
+      }
+    }
+
+    Assert.assertNotNull("Expected an exception to be thrown", ex);
+    String message = ex.getMessage();
+    String expectedMessage = "Usage of LOCAL INFILE is disabled. To use it enable it via the connection property allowLocalInfile=true";
+    Assert.assertEquals(message, expectedMessage);
+  }
+}


### PR DESCRIPTION
This PR is split out into four separate commits:

1. Change `MySQLConnection.getProtocol()` method scope to "public". 
    - This allows using it to issue a query cancellation.
2. Add a new option `allowLocalInfile` defaulting to "true"
    - When disabled (*i.e. set to `false`*) it throws an error if a `... LOCAL INFILE ...` query is executed without first specifying an InputStream for it. This prevents a query from specifying an arbitrary file path via a URL syntax.
    - The default is set to "true" so that the existing behavior is preserved (i.e. no compatibility issue).
3. Change SSLSocketFactory to set `autoClose` to true when creating the SSLSocket
    - This fixes SSL connections from hanging when they're closed.
    - See this [JDK bug](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6932592) for more info
4. Enhance custom SSL certificate handling to allow specifying multiple certificates.
    - The existing SSL certificate code (*originally written by me :)*) only handles loading a single certificate. This patch allows more than one certificate to be specified.
    - A use case for this is having both the old and new versions of the CA cert for your database. That way when the SSL certificate on your server is rotated there won't be any downtime for your app.

Let me know if I should split them out into separate PRs (rather than just separate commits). I figured this would be easier as it avoids creating a bunch of intermediate merge commits.