### PR TITLE
Update apt repo in travis setup script

### DIFF
--- a/.travis/before_test.sh
+++ b/.travis/before_test.sh
@@ -37,7 +37,7 @@ else
     sudo apt-get install python-software-properties
 
     sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db
-    sudo add-apt-repository "deb http://ftp.igh.cnrs.fr/pub/mariadb/repo/${MARIA_VERSION}/ubuntu precise main"
+    sudo add-apt-repository "deb http://nyc2.mirrors.digitalocean.com/mariadb/repo/${MARIA_VERSION}/ubuntu precise main"
 
     sudo apt-get update
 


### PR DESCRIPTION
This commit updates the Travis build script to use the DO NYC mirror. It fixes the transient CI build errors that were happening when trying to install the MariaDB server prior to running the driver tests.

FYI, I got the mirror URL from the MariaDB website: https://downloads.mariadb.org/mariadb/repositories/

This patch also adds a newline at the end of the script as it was missing.