### PR TITLE
Change Apache DBCP scope to test in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,7 @@
             <groupId>commons-dbcp</groupId>
             <artifactId>commons-dbcp</artifactId>
             <version>1.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <reporting>

--- a/src/test/java/org/mariadb/jdbc/ConnectionPoolTest.java
+++ b/src/test/java/org/mariadb/jdbc/ConnectionPoolTest.java
@@ -9,14 +9,6 @@ import java.util.Properties;
 import org.junit.Test;
 
 public class ConnectionPoolTest extends BaseTest {
-    
-    /* For this test case to compile the following must be added to the pom.xml:
-       <dependency>
-         <groupId>commons-dbcp</groupId>
-         <artifactId>commons-dbcp</artifactId>
-         <version>1.4</version>
-      </dependency>
-     */
     @Test
     public void testConnectionWithApacheDBCP() throws SQLException {
         org.apache.commons.dbcp.BasicDataSource dataSource;


### PR DESCRIPTION
The first commit changes the scope of the DBCP dependency to "test" as it's only used in the tests. The second removes an out of date comment regarding adding the DBCP dependency to the pom to run the tests.

This isn't a breaking change from a functionality perspective as the driver itself hasn't changed at all. It may break downstream apps that are relying on the transitive dependency for DBCP. That's wrong on their part though so I don't think it's a real issue. Anybody who runs into that will see the error at compile time and will need to update their pom to explicitly include DBCP themselves.

Might want to add a line like that to the release notes for the next release of the driver.