### PR TITLE
Fix trustServerCertificate SSL Option

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -189,7 +189,7 @@ public class MySQLProtocol implements Protocol {
 
     private InputStream localInfileInputStream;
 
-    private SSLSocketFactory getSSLSocketFactory(boolean trustServerCertificate)  throws QueryException
+    private SSLSocketFactory getSSLSocketFactory() throws QueryException
     {
         if (!jdbcUrl.getOptions().trustServerCertificate
                 && jdbcUrl.getOptions().serverSslCert == null) {
@@ -341,7 +341,7 @@ public class MySQLProtocol implements Protocol {
                 AbbreviatedMySQLClientAuthPacket amcap = new AbbreviatedMySQLClientAuthPacket(capabilities);
                 amcap.send(writer);
 
-                SSLSocketFactory f = getSSLSocketFactory(jdbcUrl.getOptions().trustServerCertificate);
+                SSLSocketFactory f = getSSLSocketFactory();
                 SSLSocket sslSocket = (SSLSocket)f.createSocket(socket,
                         socket.getInetAddress().getHostAddress(),  socket.getPort(), true);
 

--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -91,7 +91,6 @@ import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 class MyX509TrustManager implements X509TrustManager {
-    boolean trustServerCeritifcate;
     String serverCertFile;
     X509TrustManager  trustManager;
 

--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -191,7 +191,7 @@ public class MySQLProtocol implements Protocol {
 
     private SSLSocketFactory getSSLSocketFactory(boolean trustServerCertificate)  throws QueryException
     {
-        if (jdbcUrl.getOptions().trustServerCertificate
+        if (!jdbcUrl.getOptions().trustServerCertificate
                 && jdbcUrl.getOptions().serverSslCert == null) {
             return (SSLSocketFactory)SSLSocketFactory.getDefault();
         }

--- a/src/test/java/org/mariadb/jdbc/DriverTest.java
+++ b/src/test/java/org/mariadb/jdbc/DriverTest.java
@@ -1311,9 +1311,8 @@ public class DriverTest extends BaseTest{
     @Test
     public void useSSL()  throws Exception {
         Assume.assumeTrue(haveSSL());
-        setConnection("&useSSL=1&trustServerCertificate=1");
+        setConnection("&useSSL=true&trustServerCertificate=true");
         connection.createStatement().execute("select 1");
-
     }
 
     @Test


### PR DESCRIPTION
This fixes #30. See that issue for full details of what's broken and what this fixes.

It also includes a couple cosmetic fixes for removing unused SSL variables and the unused parameter of the `getSSLSocketFactory(...)` method. I've tested the fixed SSL option locally and it's working.

Unfortunately I haven't gotten the Travis test environment to actually run the SSL tests as the servers it tests against do not have SSL enabled. The Travis setup script will need to be modified to configure SSL and I haven't gotten around to that yet. Will probably submit it in a separate PR if nobody else gets around to it first.