### PR TITLE
Fix Travis-CI SSL

### DIFF
--- a/.travis/before_test.sh
+++ b/.travis/before_test.sh
@@ -50,6 +50,18 @@ max_allowed_packet=$MAX_ALLOWED_PACKET
 innodb_log_file_size=$INNODB_LOG_FILE_SIZE
 END
 
+# Generate SSL files:
+sudo .travis/gen-ssl.sh mariadb.example.com /etc/mysql
+sudo chown mysql:mysql /etc/mysql/server.crt /etc/mysql/server.key /etc/mysql/ca.crt
+
+# Enable SSL:
+sudo tee /etc/mysql/conf.d/ssl.cnf << END
+[mysqld]
+ssl-ca=/etc/mysql/ca.crt
+ssl-cert=/etc/mysql/server.crt
+ssl-key=/etc/mysql/server.key
+END
+
 sudo mysql -u root -e "SET GLOBAL innodb_fast_shutdown = 1"
 sudo service mysql stop
 sudo rm -f /var/lib/mysql/ib_logfile*

--- a/.travis/gen-ssl.sh
+++ b/.travis/gen-ssl.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+log () {
+  echo "$@" 1>&2
+}
+
+print_error () {
+  echo "$@" 1>&2
+  exit 1
+}
+
+print_usage () {
+  print_error "Usage: gen-ssl-cert-key <fqdn> <output-dir>"
+}
+
+gen_cert_subject () {
+  local fqdn="$1"
+  [[ "${fqdn}" != "" ]] || print_error "FQDN cannot be blank"
+  echo "/C=/ST=/O=/localityName=/commonName=${fqdn}/organizationalUnitName=/emailAddress=/"
+}
+
+main () {
+  local fqdn="$1"
+  local sslDir="$2"
+  [[ "${fqdn}" != "" ]] || print_usage
+  [[ -d "${sslDir}" ]] || print_error "Directory does not exist: ${sslDir}"
+
+  local caCertFile="${sslDir}/ca.crt"
+  local caKeyFile="${sslDir}/ca.key"
+  local certFile="${sslDir}/server.crt"
+  local keyFile="${sslDir}/server.key"
+  local csrFile=$(mktemp)
+
+  log "Generating CA key"
+  openssl genrsa -out "${caKeyFile}" 2048
+
+  log "Generating CA certificate"
+  openssl req \
+    -sha1 \
+    -new \
+    -x509 \
+    -nodes \
+    -days 3650 \
+    -subj "$(gen_cert_subject ca.example.com)" \
+    -key "${caKeyFile}" \
+    -out "${caCertFile}"
+
+  log "Generating private key"
+  openssl genrsa -out "${keyFile}" 2048
+
+  log "Generating certificate signing request"
+  openssl req \
+    -new \
+    -batch \
+    -sha1 \
+    -subj "$(gen_cert_subject "$fqdn")" \
+    -set_serial 01 \
+    -key "${keyFile}" \
+    -out "${csrFile}" \
+    -nodes
+
+  log "Generating X509 certificate"
+  openssl x509 \
+    -req \
+    -sha1 \
+    -set_serial 01 \
+    -CA "${caCertFile}" \
+    -CAkey "${caKeyFile}" \
+    -days 3650 \
+    -in "${csrFile}" \
+    -signkey "${keyFile}" \
+    -out "${certFile}"
+
+  # Clean up CSR file:
+  rm "$csrFile"
+
+  log "Generated key file and certificate in: ${sslDir}"
+  ls -l "${sslDir}"
+}
+
+main "$@"

--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -189,7 +189,7 @@ public class MySQLProtocol implements Protocol {
 
     private InputStream localInfileInputStream;
 
-    private SSLSocketFactory getSSLSocketFactory(boolean trustServerCertificate)  throws QueryException
+    private SSLSocketFactory getSSLSocketFactory() throws QueryException
     {
         if (!jdbcUrl.getOptions().trustServerCertificate
                 && jdbcUrl.getOptions().serverSslCert == null) {
@@ -341,7 +341,7 @@ public class MySQLProtocol implements Protocol {
                 AbbreviatedMySQLClientAuthPacket amcap = new AbbreviatedMySQLClientAuthPacket(capabilities);
                 amcap.send(writer);
 
-                SSLSocketFactory f = getSSLSocketFactory(jdbcUrl.getOptions().trustServerCertificate);
+                SSLSocketFactory f = getSSLSocketFactory();
                 SSLSocket sslSocket = (SSLSocket)f.createSocket(socket,
                         socket.getInetAddress().getHostAddress(),  socket.getPort(), true);
 

--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -91,7 +91,6 @@ import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 class MyX509TrustManager implements X509TrustManager {
-    boolean trustServerCeritifcate;
     String serverCertFile;
     X509TrustManager  trustManager;
 

--- a/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/mysql/MySQLProtocol.java
@@ -191,7 +191,7 @@ public class MySQLProtocol implements Protocol {
 
     private SSLSocketFactory getSSLSocketFactory(boolean trustServerCertificate)  throws QueryException
     {
-        if (jdbcUrl.getOptions().trustServerCertificate
+        if (!jdbcUrl.getOptions().trustServerCertificate
                 && jdbcUrl.getOptions().serverSslCert == null) {
             return (SSLSocketFactory)SSLSocketFactory.getDefault();
         }

--- a/src/test/java/org/mariadb/jdbc/DriverTest.java
+++ b/src/test/java/org/mariadb/jdbc/DriverTest.java
@@ -1311,9 +1311,8 @@ public class DriverTest extends BaseTest{
     @Test
     public void useSSL()  throws Exception {
         Assume.assumeTrue(haveSSL());
-        setConnection("&useSSL=1&trustServerCertificate=1");
+        setConnection("&useSSL=true&trustServerCertificate=true");
         connection.createStatement().execute("select 1");
-
     }
 
     @Test

--- a/src/test/java/org/mariadb/jdbc/SSLValidationTest.java
+++ b/src/test/java/org/mariadb/jdbc/SSLValidationTest.java
@@ -11,19 +11,18 @@ import java.sql.*;
 import java.util.Properties;
 
 public class SSLValidationTest extends BaseTest {
-	String serverCertificateCaPath;
-    String serverCertificatePath;
+	String serverCertificatePath;
 
     @Before
-     public  void checkSSL() throws SQLException{
+    public  void checkSSL() throws SQLException{
         super.before();
         org.junit.Assume.assumeTrue(haveSSL());
-        ResultSet rs =  connection.createStatement().executeQuery("select @@ssl_ca");
+        ResultSet rs =  connection.createStatement().executeQuery("select @@ssl_cert");
         rs.next();
         serverCertificatePath = rs.getString(1);
+        log.debug("Server certificate path: {}", serverCertificatePath);
         rs.close();
-     }
-
+    }
 
 	private String getServerCertificate() {
 		BufferedReader br = null;

--- a/src/test/java/org/mariadb/jdbc/SSLValidationTest.java
+++ b/src/test/java/org/mariadb/jdbc/SSLValidationTest.java
@@ -68,7 +68,9 @@ public class SSLValidationTest extends BaseTest {
 		String jdbcUrl = connURI;
 		Properties connProps = new Properties(info);
 		connProps.setProperty("user", username);
-		connProps.setProperty("password", password);
+		if( password != null ) {
+		    connProps.setProperty("password", password);
+		}
 		return openNewConnection(jdbcUrl, connProps);
 	}
 


### PR DESCRIPTION
This patch fixes the Travis-CI server setup to configure SSL for the server versions that are tested. It also fixes some of the SSL tests so they run successfully (*the null password was breaking them*).

It's layered atop PR #31 (*as without that none of the trustServerCertificate tests would work*) and closes out #32.