### PR TITLE
Fix Statement.getMoreResults() returning wrong value 

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MySQLStatement.java
+++ b/src/main/java/org/mariadb/jdbc/MySQLStatement.java
@@ -972,7 +972,7 @@ public class MySQLStatement implements Statement {
             if(queryResult == null) return false;
             warningsCleared = false;
             connection.reenableWarnings();
-            return true;
+            return queryResult.getResultSetType() == ResultSetType.SELECT;
         } catch (QueryException e) {
             SQLExceptionMapper.throwException(e, connection, this);
             return false;
@@ -1008,7 +1008,7 @@ public class MySQLStatement implements Statement {
                 throw (SQLException)o;
 
             queryResult = (QueryResult)o;
-            return true;
+            return queryResult.getResultSetType() == ResultSetType.SELECT;
         }
         return getMoreResults(false);
     }

--- a/src/test/java/org/mariadb/jdbc/DriverTest.java
+++ b/src/test/java/org/mariadb/jdbc/DriverTest.java
@@ -1438,8 +1438,8 @@ public class DriverTest extends BaseTest{
             assertEquals(-1,st.getUpdateCount());
             assertTrue(st.getResultSet() != null);
             
-            /* has more results */
-            assertTrue(st.getMoreResults()); 
+            /* Next result is no ResultSet */
+			assertFalse(st.getMoreResults());
             
             /* Second result (use) */
             assertEquals(0,st.getUpdateCount());


### PR DESCRIPTION
This pull request contains a fix for the getMoreResults method in MySQLStatement always returning true when there was a next result, instead of only returning true when the next result is a ResultSet. The related issue on Jira can be found here: https://mariadb.atlassian.net/browse/CONJ-179. 