### PR TITLE
support a keystore for both client and server certificates

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/MyX509TrustManager.java
+++ b/src/main/java/org/mariadb/jdbc/internal/MyX509TrustManager.java
@@ -56,9 +56,11 @@ import org.mariadb.jdbc.internal.util.Options;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
+
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.net.URL;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -69,6 +71,8 @@ import java.util.UUID;
 
 public class MyX509TrustManager implements X509TrustManager {
     String serverCertFile;
+    public String keystoreUrl;
+    public String certKeystorePassword;
     X509TrustManager trustManager;
 
     /**
@@ -83,31 +87,47 @@ public class MyX509TrustManager implements X509TrustManager {
         }
 
         serverCertFile = options.serverSslCert;
-        InputStream inStream;
-
-        if (serverCertFile.startsWith("-----BEGIN CERTIFICATE-----")) {
-            inStream = new ByteArrayInputStream(serverCertFile.getBytes());
-        } else if (serverCertFile.startsWith("classpath:")) {
-            // Load it from a classpath relative file
-            String classpathFile = serverCertFile.substring("classpath:".length());
-            inStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(classpathFile);
-        } else {
-            inStream = new FileInputStream(serverCertFile);
-        }
-
-        CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        Collection<? extends Certificate> caList = cf.generateCertificates(inStream);
-        inStream.close();
+        keystoreUrl = options.trustCertificateKeyStoreUrl;
+        InputStream inStream = null;
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-        try {
-            // Note: KeyStore requires it be loaded even if you don't load anything into it:
-            ks.load(null);
-        } catch (Exception e) {
 
+        if (keystoreUrl != null) {
+            // use the provided keystore
+            try {
+                inStream = new URL(keystoreUrl).openStream();
+                ks.load(inStream, options.trustCertificateKeyStorePassword == null ? null : options.trustCertificateKeyStorePassword.toCharArray());
+            } finally {
+                if (inStream != null) {
+                    inStream.close();
+                }
+            }
+        } else {
+            // generate a keystore from the provided cert
+            if (serverCertFile.startsWith("-----BEGIN CERTIFICATE-----")) {
+                inStream = new ByteArrayInputStream(serverCertFile.getBytes());
+            } else if (serverCertFile.startsWith("classpath:")) {
+                // Load it from a classpath relative file
+                String classpathFile = serverCertFile.substring("classpath:".length());
+                inStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(classpathFile);
+            } else {
+                inStream = new FileInputStream(serverCertFile);
+            }
+
+            ks = KeyStore.getInstance(KeyStore.getDefaultType());
+            try {
+                // Note: KeyStore requires it be loaded even if you don't load anything into it:
+                ks.load(null);
+            } catch (Exception e) {
+
+            }
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            Collection<? extends Certificate> caList = cf.generateCertificates(inStream);
+            inStream.close();
+            for (Certificate ca : caList) {
+                ks.setCertificateEntry(UUID.randomUUID().toString(), ca);
+            }
         }
-        for (Certificate ca : caList) {
-            ks.setCertificateEntry(UUID.randomUUID().toString(), ca);
-        }
+
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         tmf.init(ks);
         for (TrustManager tm : tmf.getTrustManagers()) {

--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
@@ -82,16 +82,21 @@ import org.mariadb.jdbc.internal.packet.send.SendSslConnectionRequestPacket;
 import org.mariadb.jdbc.internal.stream.DecompressInputStream;
 import org.mariadb.jdbc.internal.stream.PacketOutputStream;
 
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
+
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.URL;
 import java.nio.ByteBuffer;
+import java.security.KeyStore;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.locks.ReentrantLock;
@@ -222,19 +227,49 @@ public abstract class AbstractConnectProtocol implements Protocol {
 
     private SSLSocketFactory getSslSocketFactory() throws QueryException {
         if (!urlParser.getOptions().trustServerCertificate
-                && urlParser.getOptions().serverSslCert == null) {
+                && urlParser.getOptions().serverSslCert == null
+                && urlParser.getOptions().trustCertificateKeyStoreUrl == null
+                && urlParser.getOptions().clientCertificateKeyStoreUrl == null) {
             return (SSLSocketFactory) SSLSocketFactory.getDefault();
         }
 
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");
-            X509TrustManager[] trustManager = {new MyX509TrustManager(urlParser.getOptions())};
-            sslContext.init(null, trustManager, null);
+
+            X509TrustManager[] trustManager = null;
+            if (urlParser.getOptions().serverSslCert != null || urlParser.getOptions().trustCertificateKeyStoreUrl != null) {
+                trustManager = new X509TrustManager[]{new MyX509TrustManager(urlParser.getOptions())};
+            }
+
+            KeyManager[] keyManager = null;
+            String clientCertKeystoreUrl = urlParser.getOptions().clientCertificateKeyStoreUrl;
+            if (clientCertKeystoreUrl != null && !clientCertKeystoreUrl.isEmpty()) {
+                keyManager = loadClientCerts(clientCertKeystoreUrl, urlParser.getOptions().clientCertificateKeyStorePassword);
+            }
+
+            sslContext.init(keyManager, trustManager, null);
             return sslContext.getSocketFactory();
         } catch (Exception e) {
             throw new QueryException(e.getMessage(), 0, "HY000", e);
         }
 
+    }
+
+    private KeyManager[] loadClientCerts(String keystoreUrl, String keystorePassword) throws Exception {
+        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        InputStream inStream = null;
+        try {
+            char[] certKeystorePassword = keystorePassword == null ? null : keystorePassword.toCharArray();
+            inStream = new URL(keystoreUrl).openStream();
+            KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+            ks.load(inStream, certKeystorePassword);
+            keyManagerFactory.init(ks, certKeystorePassword);
+        } finally {
+            if (inStream != null) {
+                inStream.close();
+            }
+        }
+        return keyManagerFactory.getKeyManagers();
     }
 
     /**

--- a/src/main/java/org/mariadb/jdbc/internal/util/DefaultOptions.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/DefaultOptions.java
@@ -203,9 +203,9 @@ public enum DefaultOptions {
     TRUST_SERVER_CERTIFICATE("trustServerCertificate", Boolean.FALSE, "1.1.1"),
 
     /**
-     * Server's certificatem in DER form, or server's CA certificate. Can be used in one of 3 forms, sslServerCert=/path/to/cert.pem
+     * Server's certificate in DER form, or server's CA certificate. Can be used in one of 3 forms, sslServerCert=/path/to/cert.pem
      * (full path to certificate), sslServerCert=classpath:relative/cert.pem (relative to current classpath), or as verbatim DER-encoded certificate
-     * string "------BEGING CERTIFICATE-----".
+     * string "-----BEGIN CERTIFICATE-----".
      */
     SERVER_SSL_CERT("serverSslCert", "1.1.3"),
 
@@ -314,8 +314,27 @@ public enum DefaultOptions {
      * if allowMultiQueries or rewriteBatchedStatements is set to true, this options will be set to false.
      * default to true.
      */
-    USESERVERPREPSTMTS("useServerPrepStmts", Boolean.TRUE, "1.3.0");
+    USESERVERPREPSTMTS("useServerPrepStmts", Boolean.TRUE, "1.3.0"),
 
+    /**
+     * Use the specified keystore for trusted root certificates. Overrides serverSslCert.
+     */
+    TRUST_CERTIFICATE_KEYSTORE_URL("trustCertificateKeyStoreUrl", "1.3.0"),
+
+    /**
+     * Password for the trusted root certificate keystore.
+     */
+    TRUST_CERTIFICATE_KEYSTORE_PASSWORD("trustCertificateKeyStorePassword", "1.3.0"),
+
+    /**
+     * Use the specified keystore for client certificates (can be the same as the trusted root certificate keystore).
+     */
+    CLIENT_CERTIFICATE_KEYSTORE_URL("clientCertificateKeyStoreUrl", "1.3.0"),
+
+    /**
+     * Password for the client certificate keystore.
+     */
+    CLIENT_CERTIFICATE_KEYSTORE_PASSWORD("clientCertificateKeyStorePassword", "1.3.0");
 
     protected final String name;
     protected final Object objType;

--- a/src/main/java/org/mariadb/jdbc/internal/util/Options.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/Options.java
@@ -57,6 +57,10 @@ public class Options {
     //divers
     public boolean trustServerCertificate;
     public String serverSslCert;
+    public String trustCertificateKeyStoreUrl;
+    public String trustCertificateKeyStorePassword;
+    public String clientCertificateKeyStoreUrl;
+    public String clientCertificateKeyStorePassword;
     public boolean useFractionalSeconds;
     public boolean pinGlobalTxToPhysicalConnection;
     public String socketFactory;
@@ -115,6 +119,10 @@ public class Options {
                 + ", serverSslCert='" + serverSslCert + '\''
                 + ", useFractionalSeconds=" + useFractionalSeconds
                 + ", pinGlobalTxToPhysicalConnection=" + pinGlobalTxToPhysicalConnection
+                + ", trustCertificateKeyStoreUrl='" + trustCertificateKeyStoreUrl + '\''
+                + ", trustCertificateKeyStorePassword='" + trustCertificateKeyStorePassword + '\''
+                + ", clientCertificateKeyStoreUrl='" + clientCertificateKeyStoreUrl + '\''
+                + ", clientCertificateKeyStorePassword='" + clientCertificateKeyStorePassword + '\''
                 + ", socketFactory='" + socketFactory + '\''
                 + ", connectTimeout=" + connectTimeout
                 + ", pipe='" + pipe + '\''


### PR DESCRIPTION
This is the patch I sent to Diego directly, modified as he requested to use the same properties for the keystores that MySql uses.
Testcases are still to-do.