### PR TITLE
Fix unit of default value of retriesAllDown in the documentation

### DIFF
--- a/documentation/Failover-and-high-availability.md
+++ b/documentation/Failover-and-high-availability.md
@@ -146,7 +146,7 @@ Each parameter corresponds to a specific use case:
 |Option|Description|
 |-----------|:----------|
 |autoReconnect|With basic failover: if true, will attempt to recreate connection after a failover. <br/>With standard failover: if true, will attempt to recreate connection even if there is a temporary solution (like using a master connection temporary until reconnect to a slave connection).<br/>*Default is false. Since 1.1.7*|
-|retriesAllDown|When searching a valid host, maximum number of connection attempts before throwing an exception.<br/>*Default: 120 seconds. Since 1.2.0|
+|retriesAllDown|When searching a valid host, maximum number of connection attempts before throwing an exception.<br/>*Default: 120. Since 1.2.0|
 |failoverLoopRetries|When searching silently for a valid host, maximum number of connection attempts.<br/>This differ from "retriesAllDown" parameter, because this silent search is for example used after a disconnection of a slave connection when using the master connection.<br/>*Default: 120. Since 1.2.0*|
 |validConnectionTimeout|With multiple hosts, after this time in seconds has elapsed it’s verified that the connections haven’t been lost.<br/>When 0, no verification will be done.<br/>*Default:120 seconds. Since 1.2.0*|
 |loadBalanceBlacklistTimeout|When a connection fails, this host will be blacklisted during the "loadBalanceBlacklistTimeout" amount of time.<br/>When connecting to a host, the driver will try to connect to a host in the list of not blacklisted hosts and after that only on blacklisted ones if none has been found before that.<br/>This blacklist is shared inside the classloader.<br/>*Default: 50 seconds. Since 1.2.0*|


### PR DESCRIPTION
As described in "Description" of "Failover / high availability options" section,
"retriesAllDown" means not seconds but the maximum number of connection attempts,
so I removed "seconds" from it.