### PR TITLE
MastersListener: Fixed several issues around thread pool usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,12 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>org.threadly</groupId>
+            <artifactId>threadly</artifactId>
+            <version>4.4.3</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>

--- a/src/main/java/org/mariadb/jdbc/internal/failover/AbstractMastersListener.java
+++ b/src/main/java/org/mariadb/jdbc/internal/failover/AbstractMastersListener.java
@@ -85,7 +85,7 @@ public abstract class AbstractMastersListener implements Listener {
     public final UrlParser urlParser;
     protected AtomicInteger currentConnectionAttempts = new AtomicInteger();
     protected AtomicBoolean currentReadOnlyAsked = new AtomicBoolean();
-    protected AtomicReference<FailLoop> runningFailLoop = new AtomicReference<>();
+    private AtomicReference<FailLoop> runningFailLoop = new AtomicReference<>();
     protected Protocol currentProtocol = null;
     protected FailoverProxy proxy;
     protected long lastRetry = 0;
@@ -432,6 +432,7 @@ public abstract class AbstractMastersListener implements Listener {
                 } else {
                     scheduledFuture.cancel(false);
                     scheduledFuture = null;
+                    return;
                 }
             }
         }

--- a/src/main/java/org/mariadb/jdbc/internal/failover/impl/AuroraListener.java
+++ b/src/main/java/org/mariadb/jdbc/internal/failover/impl/AuroraListener.java
@@ -63,7 +63,6 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class AuroraListener extends MastersSlavesListener {
     /**
@@ -83,8 +82,7 @@ public class AuroraListener extends MastersSlavesListener {
     @Override
     public void initializeConnection() throws QueryException {
         if (urlParser.getOptions().validConnectionTimeout != 0) {
-            scheduledPing = executorService.scheduleWithFixedDelay(new PingLoop(this), urlParser.getOptions().validConnectionTimeout,
-                    urlParser.getOptions().validConnectionTimeout, TimeUnit.SECONDS);
+            pingLoop.scheduleSelf(scheduler, urlParser.getOptions().validConnectionTimeout);
         }
         try {
             reconnectFailedConnection(new SearchFilter(true, true, true));

--- a/src/main/java/org/mariadb/jdbc/internal/failover/impl/MastersFailoverListener.java
+++ b/src/main/java/org/mariadb/jdbc/internal/failover/impl/MastersFailoverListener.java
@@ -65,7 +65,6 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class MastersFailoverListener extends AbstractMastersListener {
     private final HaMode mode;
@@ -121,17 +120,7 @@ public class MastersFailoverListener extends AbstractMastersListener {
             proxy.lock.lock();
             setExplicitClosed(true);
             try {
-                //closing first additional thread if running to avoid connection creation before closing
-                if (scheduledFailover != null) {
-                    scheduledFailover.cancel(true);
-                    isLooping.set(false);
-                }
-                executorService.shutdownNow();
-                try {
-                    executorService.awaitTermination(15L, TimeUnit.SECONDS);
-                } catch (InterruptedException e) {
-                    //executorService interrupted
-                }
+                shutdownScheduler();
 
                 //closing connection
                 if (currentProtocol != null && this.currentProtocol.isConnected()) {

--- a/src/main/java/org/mariadb/jdbc/internal/util/SchedulerServiceProviderHolder.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/SchedulerServiceProviderHolder.java
@@ -1,0 +1,174 @@
+package org.mariadb.jdbc.internal.util;
+
+/*
+MariaDB Client for Java
+
+Copyright (c) 2012 Monty Program Ab.
+
+This library is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation; either version 2.1 of the License, or (at your option)
+any later version.
+
+This library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this library; if not, write to Monty Program Ab info@montyprogram.com.
+
+This particular MariaDB Client for Java file is work
+derived from a Drizzle-JDBC. Drizzle-JDBC file which is covered by subject to
+the following copyright and notice provisions:
+
+Copyright (c) 2009-2011, Marcus Eriksson
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the driver nor the names of its contributors may not be
+used to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS  AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Provider for when ever an internal thread pool is needed.  This can allow library users to 
+ * override our default pooling behavior with possibly better and faster options.
+ */
+public class SchedulerServiceProviderHolder {
+    /**
+     * The default provider will construct a new pool on every request.  Shutdown of pools returned
+     * from this provider is restricted, forcing them to use 
+     * {@link SchedulerProvider#shutdownScheduler(ScheduledExecutorService)}.
+     */
+    protected static SchedulerProvider DEFAULT_PROVIDER = new SchedulerProvider() {
+        @Override
+        public ScheduledExecutorService getScheduler(int minimumThreads) {
+            return new ShutdownRestrictedScheduledExecutorService(minimumThreads);
+        }
+
+        @Override
+        public void shutdownScheduler(ScheduledExecutorService scheduler) {
+            ((ShutdownRestrictedScheduledExecutorService)scheduler).uncheckedShutdown();
+        }
+    };
+    
+    private static volatile SchedulerProvider currentProvider = null;
+    
+    /**
+     * Change the current set scheduler provider.  This provider will be provided in future requests 
+     * to {@link #getSchedulerProvider()}.
+     * 
+     * @param newProvider New provider to use, or {@code null} to use the default provider
+     */
+    public static void setSchedulerProvider(SchedulerProvider newProvider) {
+        currentProvider = newProvider;
+    }
+    
+    /**
+     * Get the currently set {@link SchedulerProvider} from set invocations via 
+     * {@link #setSchedulerProvider(SchedulerProvider)}.  If none has been set a default provider 
+     * will be provided (never a {@code null} result).
+     * 
+     * @return Provider to get scheduler pools from
+     */
+    public static SchedulerProvider getSchedulerProvider() {
+        SchedulerProvider result = currentProvider;
+        if (result == null) {
+            return DEFAULT_PROVIDER;
+        } else {
+            return result;
+        }
+    }
+    
+    /**
+     * <p>Provider for thread pools which allow scheduling capabilities.  It is expected that the 
+     * thread pools entire lifecycle (start to stop) is done through the same provider instance.</p>
+     */
+    public interface SchedulerProvider {
+        /**
+         * Request to get a scheduler with a minimum number of AVAILABLE threads.  The scheduler 
+         * returned from this should not be shutdown directly, but instead 
+         * {@link #shutdownScheduler(ScheduledExecutorService)} should be invoked once ready to be 
+         * shutdown.
+         * 
+         * @param minimumThreads Minimum number of available threads for the returned scheduler
+         * @return A new scheduler that is ready to accept tasks
+         */
+        public ScheduledExecutorService getScheduler(int minimumThreads);
+        
+        /**
+         * Once a scheduler provided by this provider is ready to be shutdown, this should be 
+         * invoked.  It is expected that ONLY schedulers produced by this provider will be accepted 
+         * for shutdown, if a different scheduler is provided behavior is undefined.
+         * 
+         * @param scheduler Previously provided scheduler to be shutdown
+         */
+        public void shutdownScheduler(ScheduledExecutorService scheduler);
+    }
+    
+    /**
+     * Small class which restricts shutdown actions.  Attempts to shutdown will result in an 
+     * {@link UnsupportedOperationException}.  Instead shutdown should be invoked through 
+     * {@link ShutdownRestrictedScheduledExecutorService#uncheckedShutdown()}.
+     */
+    private static class ShutdownRestrictedScheduledExecutorService extends ScheduledThreadPoolExecutor {
+        private static final AtomicInteger POOL_ID = new AtomicInteger();
+
+        public ShutdownRestrictedScheduledExecutorService(int corePoolSize) {
+            super(corePoolSize, new ThreadFactory() {
+                private final int thisPoolId = POOL_ID.incrementAndGet();
+                // start from DefaultThread factory to get security groups and what not
+                private final ThreadFactory parentFactory = Executors.defaultThreadFactory();
+                private final AtomicInteger threadId = new AtomicInteger();
+
+                @Override
+                public Thread newThread(Runnable runnable) {
+                    Thread result = parentFactory.newThread(runnable);
+                    result.setName("mariaDb-" + thisPoolId + "-" + threadId.incrementAndGet());
+                    
+                    return result;
+                }
+            });
+        }
+        
+        protected void uncheckedShutdown() {
+            super.shutdownNow();
+        }
+        
+        @Override
+        public List<Runnable> shutdownNow() {
+            throw new UnsupportedOperationException("Pool must be shutdown through scheduler provider");
+        }
+        
+        @Override
+        public void shutdown() {
+            throw new UnsupportedOperationException("Pool must be shutdown through scheduler provider");
+        }
+    }
+}

--- a/src/test/java/org/mariadb/jdbc/failover/BaseReplication.java
+++ b/src/test/java/org/mariadb/jdbc/failover/BaseReplication.java
@@ -9,9 +9,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 public abstract class BaseReplication extends BaseMultiHostTest {
 
@@ -268,17 +265,7 @@ public abstract class BaseReplication extends BaseMultiHostTest {
             Statement stmt = connection.createStatement();
             stmt.execute("SELECT 1");
             //launch connection close
-            ExecutorService exec = Executors.newFixedThreadPool(2);
-            exec.execute(new CloseConnection(connection));
-
-            Thread.sleep(3000);
-            exec.shutdown();
-            try {
-                exec.awaitTermination(20, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-                Assert.fail();
-            }
+            new CloseConnection(connection).run();
         } finally {
             if (connection != null) {
                 if (connection != null) {

--- a/src/test/java/org/mariadb/jdbc/internal/util/SchedulerServiceProviderHolderTest.java
+++ b/src/test/java/org/mariadb/jdbc/internal/util/SchedulerServiceProviderHolderTest.java
@@ -1,0 +1,101 @@
+package org.mariadb.jdbc.internal.util;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mariadb.jdbc.internal.util.SchedulerServiceProviderHolder.SchedulerProvider;
+import org.threadly.concurrent.DoNothingRunnable;
+import org.threadly.test.concurrent.TestRunnable;
+
+public class SchedulerServiceProviderHolderTest {
+    @After
+    @Before
+    public void providerReset() {
+        SchedulerServiceProviderHolder.setSchedulerProvider(null);
+    }
+    
+    @Test
+    public void getDefaultProviderTest() {
+        assertTrue(SchedulerServiceProviderHolder.DEFAULT_PROVIDER 
+                       == SchedulerServiceProviderHolder.getSchedulerProvider());
+    }
+    
+    @Test
+    public void defaultProviderGetSchedulerTest() {
+        SchedulerProvider provider = SchedulerServiceProviderHolder.getSchedulerProvider();
+        ScheduledExecutorService scheduler = provider.getScheduler(1);
+        try {
+            assertNotNull(scheduler);
+            // verify scheduler works
+            TestRunnable tr = new TestRunnable();
+            scheduler.execute(tr);
+            tr.blockTillFinished(); // will throw exception if timeout
+        } finally {
+            provider.shutdownScheduler(scheduler);
+        }
+    }
+    
+    @Test
+    public void defaultProviderSchedulerShutdownTest() {
+        SchedulerProvider provider = SchedulerServiceProviderHolder.getSchedulerProvider();
+        ScheduledExecutorService scheduler = provider.getScheduler(1);
+        
+        provider.shutdownScheduler(scheduler);
+        
+        try {
+            scheduler.execute(DoNothingRunnable.instance());
+            
+            fail("Exception should have thrown");
+        } catch (RejectedExecutionException expected) {
+            // ignore
+        }
+    }
+    
+    @Test
+    public void defaultProviderSchedulerShutdownFail() {
+        SchedulerProvider provider = SchedulerServiceProviderHolder.getSchedulerProvider();
+        ScheduledExecutorService scheduler = provider.getScheduler(1);
+        
+        try {
+            try {
+                scheduler.shutdown();
+                fail("Exception should have thrown");
+            } catch (UnsupportedOperationException expected) {
+                // ignore
+            }
+            assertFalse(scheduler.isShutdown());
+            try {
+                scheduler.shutdownNow();
+                fail("Exception should have thrown");
+            } catch (UnsupportedOperationException expected) {
+                // ignore
+            }
+            assertFalse(scheduler.isShutdown());
+        } finally {
+            provider.shutdownScheduler(scheduler);
+        }
+    }
+    
+    @Test
+    public void setAndGetProviderTest() {
+        SchedulerProvider emptyProvider = new SchedulerProvider() {
+            @Override
+            public ScheduledExecutorService getScheduler(int minimumThreads) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void shutdownScheduler(ScheduledExecutorService scheduler) {
+                throw new UnsupportedOperationException();
+            }
+        };
+        
+        SchedulerServiceProviderHolder.setSchedulerProvider(emptyProvider);
+        assertTrue(emptyProvider == SchedulerServiceProviderHolder.getSchedulerProvider());
+    }
+}

--- a/src/test/resources/style.xml
+++ b/src/test/resources/style.xml
@@ -111,7 +111,6 @@
             <message key="name.invalidPattern"
                      value="Method type name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        <module name="NoFinalizer"/>
         <module name="GenericWhitespace">
             <message key="ws.followed"
                      value="GenericWhitespace ''{0}'' is followed by whitespace."/>


### PR DESCRIPTION
A bit of a sizable commit, several things are included, though they are all closely related.  Because this one may have less obvious changes than my previous pull request, please ask questions.

This pull request will fix all the defects I found and fixed in our fork (https://github.com/fullcontact/mariadb-connector-j).  There is one sizable difference between these.  I tried to get the thread count reduction also to work well, but it ended up being too complicated with java.util.concurrent.ScheduledThreadPoolExecutor.  So this has the same thread #'s that current master has.  However as you will see in one of my bullets and the changes, I did add a way for library users to change how the pool's are constructed and live.  This should allow us to override this behavior within the library so that we can at least get better thread counts (or anyone else who wants to include threadly).  Let me know if there are any questions or concerns, but we would at least like to be able to use a substantially better pool than what java.util.concurrent provides.

The following defects in AbstractMastersListener were fixed:
* Thread leakage which results in threads to continue to grow without bounds till the server runs out of memory
    The issue here is that ScheduledThreadPoolExecutor does not cleanup started threads once allowed to be garbage collected (arguably a defect in the java classpath, this is due to the inner class of ThreadPoolExecutor "Worker" not being static, and thus holding on to a reference of the pool).

    The fix here was to use a common pool for the ping and fail loop that has a normal start/shutdown lifecycle.

* Fixed issue where FailLoop may fail to stop, as well as allowing multiple FailLoop's to be started
    Condition possible when:
    Thread A enters 'launchFailLoopIfNotlaunched' and progresses to the point where it has transitioned the atomic boolean, but then one of two conditions happens:
         Either thread A is de-scheduled by the OS before 'scheduledFailover' is set
         ...OR... 'scheduledFailover' is set, but since it's not volatile the update is not witnessed by thread B (sadly because of the above condition this could not be solved by just setting this as volatile)
    Thread B then enters 'stopFailover', it transitions the AtomicBoolean back to false, but does not see the set 'scheduledFailover', so it does not remove the task.  I suspect this is why your doing the null check, previously when you would have got a NullPointerException, now your just leaking the task.

    This problem would be further compounded now that it is possible for another invocation to schedule a second task if 'launchFailLoopIfNotlaunched' is invoked.  The null check that existed here likely was a witness of this race condition.

    The solution here was to use an "AtomicReference" hold an instance of the "FailLoop", which can be set before scheduled.  Once set there, we let the FailLoop track its own scheduled future.  It may need to block to wait for the future to be set in a very tight condition, but otherwise unscheduling is handled interior to the task.

 Other changes:
 * Also changed was the ability to allow library users to set their own thread pools.  java.util.concurrent's thread pools are deficient in many ways (performance being one of them).  This will allow us (and others if desired) to provide their own implementations.
 * Threadly was added as a TEST dependency.  I did this because when writing unit tests for the new 'SchedulerServiceProviderHolder' I was being lazy and did not want to re-implement "TestRunnable"'s trivial blocking/verification.  I also updated a couple unit tests, one that was purely simplified, but another where I showed the use of threadly's "TestableScheduler" for deterministic execution.  If there are any concerns here, ideally I would like to just remove the test which made the dependency worth it (it's testing pretty trivial code anyways).

As with before, this is licensed under the BSD-new license.