### PR TITLE
SchedulerServiceProvider: Return interface rather than implementation

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/failover/thread/ConnectionValidator.java
+++ b/src/main/java/org/mariadb/jdbc/internal/failover/thread/ConnectionValidator.java
@@ -55,19 +55,13 @@ import org.mariadb.jdbc.internal.util.scheduler.SchedulerServiceProviderHolder;
 import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ConnectionValidator  {
-    private static final ScheduledThreadPoolExecutor fixedSizedScheduler = SchedulerServiceProviderHolder.getFixedSizeScheduler(1);
+    private static final ScheduledExecutorService fixedSizedScheduler = SchedulerServiceProviderHolder.getFixedSizeScheduler(1);
     private static final int MINIMUM_CHECK_DELAY_MILLIS = 100;
-    
-    static {
-        // set a rare thread timeout option to allow garbage collection in case class use is stopped
-        fixedSizedScheduler.setKeepAliveTime(2, TimeUnit.HOURS);
-        fixedSizedScheduler.allowCoreThreadTimeOut(true);
-    }
 
     private final ConcurrentLinkedQueue<Listener> queue = new ConcurrentLinkedQueue<>();
     private final AtomicLong currentScheduledFrequency = new AtomicLong(-1);

--- a/src/main/java/org/mariadb/jdbc/internal/util/scheduler/FixedSizedSchedulerImpl.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/scheduler/FixedSizedSchedulerImpl.java
@@ -52,6 +52,7 @@ package org.mariadb.jdbc.internal.util.scheduler;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class FixedSizedSchedulerImpl extends ScheduledThreadPoolExecutor {
@@ -76,5 +77,9 @@ public class FixedSizedSchedulerImpl extends ScheduledThreadPoolExecutor {
                 return result;
             }
         });
+
+        // set a rare thread timeout option to allow garbage collection
+        setKeepAliveTime(2, TimeUnit.HOURS);
+        allowCoreThreadTimeOut(true);
     }
 }

--- a/src/main/java/org/mariadb/jdbc/internal/util/scheduler/SchedulerServiceProviderHolder.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/scheduler/SchedulerServiceProviderHolder.java
@@ -118,7 +118,7 @@ public class SchedulerServiceProviderHolder {
      * @param initialThreadCount Number of threads scheduler is allowed to grow to
      * @return Scheduler capable of providing the needed thread count
      */
-    public static ScheduledThreadPoolExecutor getFixedSizeScheduler(int initialThreadCount) {
+    public static ScheduledExecutorService getFixedSizeScheduler(int initialThreadCount) {
         return getSchedulerProvider().getFixedSizeScheduler(initialThreadCount);
     }
 
@@ -135,7 +135,7 @@ public class SchedulerServiceProviderHolder {
          */
         public DynamicSizedSchedulerInterface getScheduler(int minimumThreads);
 
-        public ScheduledThreadPoolExecutor getFixedSizeScheduler(int minimumThreads);
+        public ScheduledExecutorService getFixedSizeScheduler(int minimumThreads);
     }
 
 


### PR DESCRIPTION
I must have missed that in the fixed size case we were returning the implementation, rather than the interface.
Changing to the interface allows for easier extension and other scheduler implementations here.