### PR TITLE
MasterSlavesListener: Fix for race condition in switchReadOnlyConnection

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/failover/AbstractMastersListener.java
+++ b/src/main/java/org/mariadb/jdbc/internal/failover/AbstractMastersListener.java
@@ -83,8 +83,7 @@ public abstract class AbstractMastersListener implements Listener {
     /* =========================== Failover variables ========================================= */
     public final UrlParser urlParser;
     protected AtomicInteger currentConnectionAttempts = new AtomicInteger();
-    protected final Object currentReadOnlyUpdateLock = new Object();
-    // currentReadOnlyAsked is volatile so can be queried with lock, but can only be updated when lock is synchronized
+    // currentReadOnlyAsked is volatile so can be queried without lock, but can only be updated when proxy.lock is locked
     protected volatile boolean currentReadOnlyAsked = false;
     protected Protocol currentProtocol = null;
     protected FailoverProxy proxy;

--- a/src/main/java/org/mariadb/jdbc/internal/failover/impl/MastersFailoverListener.java
+++ b/src/main/java/org/mariadb/jdbc/internal/failover/impl/MastersFailoverListener.java
@@ -225,12 +225,15 @@ public class MastersFailoverListener extends AbstractMastersListener {
      */
     public void switchReadOnlyConnection(Boolean mustBeReadOnly) throws QueryException {
         if (urlParser.getOptions().assureReadOnly && currentReadOnlyAsked != mustBeReadOnly) {
-            synchronized (currentReadOnlyUpdateLock) {
+            proxy.lock.lock();
+            try {
                 // verify not updated now that hold lock, double check safe due to volatile
                 if (currentReadOnlyAsked != mustBeReadOnly) {
                     currentReadOnlyAsked = mustBeReadOnly;
                     setSessionReadOnly(mustBeReadOnly, currentProtocol);
                 }
+            } finally {
+                proxy.lock.unlock();
             }
         }
     }


### PR DESCRIPTION
An AtomicBoolean does not provide a sufficent enough concurrency barrier here.
Instead I switched it to a volatile boolean + an Object that we synchronize on when the boolean is to be updated.

I am pretty sure I hit this today.  We are starting to use our aurora read replica more and more, so I am not unsurprised I might have uncovered this (or possibly another) race condition.  I had a condition where a connection, fresh from the pool (which I know had the read only state set back after it was done), complained as it tried to hit the read replica.

I hunted around for what might be the cause, and so far this is the only thing I have found.  If you have other ideas where this issue might be, please point me to where to look.

I will comment at the line where I believe the race condition existed.