### PR TITLE
prepareStatement() taking column indexes or names should use Statement.RETURN_GENERATED_KEYS flag.

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbConnection.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbConnection.java
@@ -330,7 +330,7 @@ public final class MariaDbConnection implements Connection {
      * @since 1.4
      */
     public PreparedStatement prepareStatement(final String sql, final int[] columnIndexes) throws SQLException {
-        return prepareStatement(sql);
+        return prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
     }
 
     /**
@@ -357,7 +357,7 @@ public final class MariaDbConnection implements Connection {
      * @since 1.4
      */
     public PreparedStatement prepareStatement(final String sql, final String[] columnNames) throws SQLException {
-        return prepareStatement(sql);
+        return prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
     }
 
 


### PR DESCRIPTION
At the moment these methods do not use the RETURN_GENERATED_KEYS flag and thus when there is the attempt to read the generated keys this throws an exception.

prepareStatement(final String sql, final int[] columnIndexes)
prepareStatement(final String sql, final String[] columnNames)
... should use the RETURN_GENERATED_KEYS flag (and currently do not).