### PR TITLE
Use the doubleValue of non-BigDecimal Number arguments to setObject.

### DIFF
--- a/src/main/java/org/mariadb/jdbc/AbstractMariaDbPrepareStatement.java
+++ b/src/main/java/org/mariadb/jdbc/AbstractMariaDbPrepareStatement.java
@@ -844,7 +844,7 @@ public abstract class AbstractMariaDbPrepareStatement extends MariaDbStatement i
                     if (obj instanceof BigDecimal) {
                         setBigDecimal(parameterIndex, (BigDecimal) obj);
                     } else {
-                        setLong(parameterIndex, bd.longValue());
+                        setBigDecimal(parameterIndex, new BigDecimal(bd.doubleValue()));
                     }
                     break;
                 case Types.BIT:

--- a/src/main/java/org/mariadb/jdbc/AbstractMariaDbPrepareStatement.java
+++ b/src/main/java/org/mariadb/jdbc/AbstractMariaDbPrepareStatement.java
@@ -843,8 +843,10 @@ public abstract class AbstractMariaDbPrepareStatement extends MariaDbStatement i
                 case Types.NUMERIC:
                     if (obj instanceof BigDecimal) {
                         setBigDecimal(parameterIndex, (BigDecimal) obj);
+                    } else if (obj instanceof Double || obj instanceof Float) {
+                        setDouble(parameterIndex, bd.doubleValue());
                     } else {
-                        setBigDecimal(parameterIndex, new BigDecimal(bd.doubleValue()));
+                        setLong(parameterIndex, bd.longValue());
                     }
                     break;
                 case Types.BIT:

--- a/src/test/java/org/mariadb/jdbc/PreparedStatementTest.java
+++ b/src/test/java/org/mariadb/jdbc/PreparedStatementTest.java
@@ -31,6 +31,7 @@ public class PreparedStatementTest extends BaseTest {
                         + "`Webinar10-TM/ProjComp` text",
                  "ENGINE=InnoDB DEFAULT CHARSET=utf8");
         createTable("test_insert_select","`field1` varchar(20)");
+        createTable("test_decimal_insert", "`field1` decimal(10, 7)");
     }
 
     @Test
@@ -111,6 +112,24 @@ public class PreparedStatementTest extends BaseTest {
         ResultSet rs = stmt.executeQuery();
         assertTrue(rs.next());
         assertEquals(0, rs.getBigDecimal(1).toBigInteger().compareTo(bigT));
+    }
+
+    /**
+     * setObject should not truncate doubles.
+     *
+     * @throws SQLException exception
+     */
+    @Test
+    public void testDoubleToDecimal() throws SQLException {
+        PreparedStatement stmt = sharedConnection.prepareStatement("INSERT INTO test_decimal_insert (field1) VALUES (?)");
+        Double value = 0.3456789;
+        stmt.setObject(1, value, Types.DECIMAL, 7);
+        stmt.executeUpdate();
+        stmt = sharedConnection.prepareStatement("SELECT `field1` FROM test_decimal_insert");
+        ResultSet rs = stmt.executeQuery();
+
+        assertTrue(rs.next());
+        assertEquals(value, rs.getDouble(1), 0.00000001);
     }
 
     @Test


### PR DESCRIPTION
Previously the `longValue` was used, which was incompatible with the MySQL Connector/J, and also meant that floating point numbers would lose their fractional part. This commit creates a new `BigDecimal` from the `doubleValue` instead.