### PR TITLE
Pool improvements

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbClientPreparedStatement.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbClientPreparedStatement.java
@@ -234,8 +234,8 @@ public class MariaDbClientPreparedStatement extends AbstractMariaDbPrepareStatem
         int[] ret = new int[size];
         int batchQueriesCount = 0;
         MariaDbResultSet rs = null;
-        cachedResultSets.clear();
         lock.lock();
+        cachedResultSets.clear();
         try {
             if (isRewriteable && (protocol.getOptions().allowMultiQueries || protocol.getOptions().rewriteBatchedStatements)) {
                 batchResultSet = null;

--- a/src/main/java/org/mariadb/jdbc/MariaDbServerPreparedStatement.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbServerPreparedStatement.java
@@ -288,11 +288,7 @@ public class MariaDbServerPreparedStatement extends AbstractMariaDbPrepareStatem
      Reset timeout after query, re-throw  SQL  exception
     */
     private void executeQueryEpilog(QueryException exception, String sql) throws SQLException {
-
-        if (timerTask != null) {
-            timerTask.cancel();
-            timerTask = null;
-        }
+        stopTimeoutTask();
 
         if (isTimedout) {
             isTimedout = false;

--- a/src/main/java/org/mariadb/jdbc/MariaDbServerPreparedStatement.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbServerPreparedStatement.java
@@ -255,6 +255,7 @@ public class MariaDbServerPreparedStatement extends AbstractMariaDbPrepareStatem
         return ret;
     }
 
+    // must have "lock" locked before invoking
     private boolean executeInternal(ParameterHolder[] parameters, MariaDbType[] parameterTypeHeader) throws SQLException {
         executing = true;
         QueryException exception = null;
@@ -273,6 +274,7 @@ public class MariaDbServerPreparedStatement extends AbstractMariaDbPrepareStatem
         }
     }
 
+    // must have "lock" locked before invoking
     private void executeQueryProlog(PrepareResult prepareResult) throws SQLException {
         if (closed) {
             throw new SQLException("execute() is called on closed statement");

--- a/src/main/java/org/mariadb/jdbc/MariaDbStatement.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbStatement.java
@@ -51,8 +51,9 @@ package org.mariadb.jdbc;
 
 import org.mariadb.jdbc.internal.queryresults.UpdateResult;
 import org.mariadb.jdbc.internal.util.ExceptionMapper;
-import org.mariadb.jdbc.internal.util.dao.PrepareResult;
 import org.mariadb.jdbc.internal.util.dao.QueryException;
+import org.mariadb.jdbc.internal.util.scheduler.DynamicSizedSchedulerInterface;
+import org.mariadb.jdbc.internal.util.scheduler.SchedulerServiceProviderHolder;
 import org.mariadb.jdbc.internal.queryresults.AbstractQueryResult;
 import org.mariadb.jdbc.internal.queryresults.ResultSetType;
 import org.mariadb.jdbc.internal.protocol.Protocol;
@@ -61,11 +62,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.*;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 
 public class MariaDbStatement implements Statement {
-    private static volatile Timer timer;
+    private static final DynamicSizedSchedulerInterface timeoutScheduler = 
+            SchedulerServiceProviderHolder.getScheduler(0);
     /**
      * the protocol used to talk to the server.
      */
@@ -82,7 +87,7 @@ public class MariaDbStatement implements Statement {
      * The actual query result.
      */
     protected AbstractQueryResult queryResult;
-    protected TimerTask timerTask;
+    protected Future<?> timerTaskFuture;
     protected boolean isRewriteable = true;
     protected int rewriteOffset = -1;
     protected ResultSet batchResultSet = null;
@@ -113,26 +118,11 @@ public class MariaDbStatement implements Statement {
         cachedResultSets = new ArrayDeque<>();
     }
 
-    private static Timer getTimer() {
-        Timer result = timer;
-        if (result == null) {
-            synchronized (MariaDbStatement.class) {
-                result = timer;
-                if (result == null) {
-                    timer = result = new Timer("MariaDB-JDBC-Timer", true);
-                }
-            }
-        }
-        return result;
-    }
-
     /**
      * Provide a "cleanup" method that can be called after unloading driver, to fix Tomcat's obscure classpath handling.
      */
     public static void unloadDriver() {
-        if (timer != null) {
-            timer.cancel();
-        }
+        // nothing to do here, as scheduler is already daemon thread
     }
 
     public boolean isStreaming() {
@@ -141,8 +131,11 @@ public class MariaDbStatement implements Statement {
 
     // Part of query prolog - setup timeout timer
     protected void setTimerTask() {
-        assert (timerTask == null);
-        timerTask = new TimerTask() {
+        assert (timerTaskFuture == null);
+        
+        // because canceling needs to establish a new connection, we want to ensure that this 
+        // possible blocking call can be run in parallel if multiple queries need to timeout
+        timerTaskFuture = timeoutScheduler.addThreadAndSchedule(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -151,8 +144,7 @@ public class MariaDbStatement implements Statement {
                 } catch (Throwable e) {
                 }
             }
-        };
-        getTimer().schedule(timerTask, queryTimeout * 1000);
+        }, queryTimeout, TimeUnit.SECONDS);
     }
 
     protected void executeQueryProlog() throws SQLException {
@@ -185,16 +177,32 @@ public class MariaDbStatement implements Statement {
         }
         queryResult = saveResult;
     }
+    
+    protected void stopTimeoutTask() {
+        if (timerTaskFuture != null) {
+            if (! timerTaskFuture.cancel(true)) {
+                // could not cancel, task either started or already finished
+                // we must now wait for task to finish to ensure state modifications are done
+                try {
+                    timerTaskFuture.get();
+                } catch (InterruptedException e) {
+                    // reset interrupt status
+                    Thread.currentThread().interrupt();
+                } catch (ExecutionException e) {
+                    // ignore error, likely due to interrupting during cancel
+                }
+                // we don't catch the exception if already canceled, that would indicate we tried 
+                // to cancel in parallel (which this code currently is not designed for)
+            }
+            timerTaskFuture = null;
+        }
+    }
 
     /*
      Reset timeout after query, re-throw  SQL  exception
     */
     protected void executeQueryEpilog(QueryException queryException) throws SQLException {
-
-        if (timerTask != null) {
-            timerTask.cancel();
-            timerTask = null;
-        }
+        stopTimeoutTask();
 
         if (isTimedout) {
             isTimedout = false;

--- a/src/main/java/org/mariadb/jdbc/internal/util/scheduler/DynamicSizedSchedulerImpl.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/scheduler/DynamicSizedSchedulerImpl.java
@@ -49,34 +49,15 @@ OF SUCH DAMAGE.
 
 package org.mariadb.jdbc.internal.util.scheduler;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class DynamicSizedSchedulerImpl extends ScheduledThreadPoolExecutor implements DynamicSizedSchedulerInterface {
-
-    private static final AtomicInteger POOL_ID = new AtomicInteger();
-
     /**
      * Initialize a scheduler with dynamic pool size.
      * @param corePoolSize initial Core pool size
      */
     public DynamicSizedSchedulerImpl(int corePoolSize) {
-        super(corePoolSize, new ThreadFactory() {
-            private final int thisPoolId = POOL_ID.incrementAndGet();
-            // start from DefaultThread factory to get security groups and what not
-            private final ThreadFactory parentFactory = Executors.defaultThreadFactory();
-            private final AtomicInteger threadId = new AtomicInteger();
-
-            @Override
-            public Thread newThread(Runnable runnable) {
-                Thread result = parentFactory.newThread(runnable);
-                result.setName("mariaDb-reconnection-" + thisPoolId + "-" + threadId.incrementAndGet());
-
-                return result;
-            }
-        });
+        super(corePoolSize, new MariaDbThreadFactory());
     }
 
     @Override

--- a/src/main/java/org/mariadb/jdbc/internal/util/scheduler/DynamicSizedSchedulerImpl.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/scheduler/DynamicSizedSchedulerImpl.java
@@ -49,7 +49,10 @@ OF SUCH DAMAGE.
 
 package org.mariadb.jdbc.internal.util.scheduler;
 
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class DynamicSizedSchedulerImpl extends ScheduledThreadPoolExecutor implements DynamicSizedSchedulerInterface {
     /**
@@ -62,6 +65,49 @@ public class DynamicSizedSchedulerImpl extends ScheduledThreadPoolExecutor imple
 
     @Override
     public void setPoolSize(int newSize) {
-        super.setCorePoolSize(newSize);
+        synchronized (this) {
+            super.setCorePoolSize(newSize);
+        }
+    }
+
+    @Override
+    public void adjustPoolSize(int delta) {
+        // locked to avoid check then act race condition
+        synchronized (this) {
+            super.setCorePoolSize(Math.max(0, super.getCorePoolSize() + delta));
+        }
+    }
+
+    @Override
+    public Future<?> addThreadAndExecute(final Runnable task) {
+        return addThreadAndSchedule(task, 0, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public Future<?> addThreadAndSchedule(final Runnable task, long delay, TimeUnit unit) {
+        adjustPoolSize(1);
+        
+        FutureTask<?> result = new PoolSizeDecreaseFuture(task);
+        if (delay == 0) {
+            // execute is slightly better if we can, as it avoids wrapping the future in another future
+            super.execute(result);
+        } else {
+            super.schedule(result, delay, unit);
+            // can not return future from schedule above
+            // we must return our decreasing future to handle Future.cancel case
+        }
+        return result;
+    }
+    
+    private class PoolSizeDecreaseFuture extends FutureTask<Object> {
+        public PoolSizeDecreaseFuture(Runnable runnable) {
+            super(runnable, null);
+        }
+        
+        @Override
+        protected void done() {
+            // invoked when task is complete or canceled
+            adjustPoolSize(-1);
+        }
     }
 }

--- a/src/main/java/org/mariadb/jdbc/internal/util/scheduler/DynamicSizedSchedulerInterface.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/scheduler/DynamicSizedSchedulerInterface.java
@@ -49,7 +49,9 @@ OF SUCH DAMAGE.
 
 package org.mariadb.jdbc.internal.util.scheduler;
 
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public interface DynamicSizedSchedulerInterface extends ScheduledExecutorService {
     /**
@@ -58,4 +60,32 @@ public interface DynamicSizedSchedulerInterface extends ScheduledExecutorService
      * @param newSize New pool size that is superior to 0
      */
     public void setPoolSize(int newSize);
+    
+    /**
+     * Adjusts the pool size by a given delta.  This should atomically change the pool size in a 
+     * thread safe way.
+     * 
+     * @param delta A positive or negative number to adjust the pool size by.
+     */
+    public void adjustPoolSize(int delta);
+    
+    /**
+     * Used when you want to ensure an extra thread is available to execute task.  This will adjust 
+     * the pool size so that a thread can be created (if necessary), and then execute the task.  
+     * Once the task completes the pool size will be adjusted back down.
+     * 
+     * @param task Task to be executed
+     * @return Future which represents task execution
+     */
+    public Future<?> addThreadAndExecute(Runnable task);
+
+    /**
+     * Used when you want to ensure an extra thread is available for scheduled task.  This will 
+     * adjust the pool size so that a thread can be created (if necessary), and then execute the 
+     * task.  Once the task completes the pool size will be adjusted back down.
+     * 
+     * @param task Task to be executed
+     * @return Future which represents task execution
+     */
+    public Future<?> addThreadAndSchedule(Runnable task, long delay, TimeUnit unit);
 }

--- a/src/main/java/org/mariadb/jdbc/internal/util/scheduler/FixedSizedSchedulerImpl.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/scheduler/FixedSizedSchedulerImpl.java
@@ -49,34 +49,16 @@ OF SUCH DAMAGE.
 
 package org.mariadb.jdbc.internal.util.scheduler;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class FixedSizedSchedulerImpl extends ScheduledThreadPoolExecutor {
-    private static final AtomicInteger POOL_ID = new AtomicInteger();
-
     /**
      * Create scheduler with fixed size.
      * @param corePoolSize core pool size
      */
     public FixedSizedSchedulerImpl(int corePoolSize) {
-        super(corePoolSize, new ThreadFactory() {
-            private final int thisPoolId = POOL_ID.incrementAndGet();
-            // start from DefaultThread factory to get security groups and what not
-            private final ThreadFactory parentFactory = Executors.defaultThreadFactory();
-            private final AtomicInteger threadId = new AtomicInteger();
-
-            @Override
-            public Thread newThread(Runnable runnable) {
-                Thread result = parentFactory.newThread(runnable);
-                result.setName("mariaDb-connection-validity-" + thisPoolId + "-" + threadId.incrementAndGet());
-
-                return result;
-            }
-        });
+        super(corePoolSize, new MariaDbThreadFactory());
 
         // set a rare thread timeout option to allow garbage collection
         setKeepAliveTime(2, TimeUnit.HOURS);

--- a/src/main/java/org/mariadb/jdbc/internal/util/scheduler/MariaDbThreadFactory.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/scheduler/MariaDbThreadFactory.java
@@ -1,0 +1,23 @@
+package org.mariadb.jdbc.internal.util.scheduler;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MariaDbThreadFactory implements ThreadFactory {
+    private static final AtomicInteger POOL_ID = new AtomicInteger();
+    
+    private final int thisPoolId = POOL_ID.incrementAndGet();
+    // start from DefaultThread factory to get security groups and what not
+    private final ThreadFactory parentFactory = Executors.defaultThreadFactory();
+    private final AtomicInteger threadId = new AtomicInteger();
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        Thread result = parentFactory.newThread(runnable);
+        result.setName("mariaDb-" + thisPoolId + "-" + threadId.incrementAndGet());
+        result.setDaemon(true); // set as daemon so that mariaDb wont hold up shutdown
+        
+        return result;
+    }
+}

--- a/src/main/java/org/mariadb/jdbc/internal/util/scheduler/SchedulerServiceProviderHolder.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/scheduler/SchedulerServiceProviderHolder.java
@@ -50,7 +50,6 @@ OF SUCH DAMAGE.
 */
 
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Provider for when ever an internal thread pool is needed.  This can allow library users to


### PR DESCRIPTION
It is probably easier to digest through the commit's, but I figured I would include it all in a single PR.  Feel free to make requests for individual commit adjustments (or removals).

https://github.com/MariaDB/mariadb-connector-j/commit/46c4166b3d8072f5027d9658bc7af4134a842792

This commit is address an issue @rusher pointed me to with tomcat struggling to shutdown.  His recommendation was to track the connections and unscheduled the tasks as needed, and reschedule if we end up creating new connections.

I took a different angle to this.  We have not run into these issues, and I suspect it's because we are using https://github.com/threadly/threadly/ under the hood which defaults to daemon threads.  I am not aware of anything that we would need to hold the app shutdown up for, so it seems like transitioning these threads to daemon is has the least performance impact, and is the easiest option.

https://github.com/MariaDB/mariadb-connector-j/commit/efc6405806147d4910cb75f98ecacb68b882cad8

This one was a slight pet peeve of mine, but @rusher said he would be open to seeing a possible PR solution.  I dislike Timer's because of how they create threads all over the place, and much more prefer pools.  In this implementation we use the existing `DynamicSizedScheduler` to be able to pool these requests.

I considered a trivial implementation where we just increase the pool size in `setTimerTask`, then decreased it in `stopTimeoutTask` if it's set.  But I feel like even though it's a bit more code, it's worth it to support this natively in the `DynamicSizedScheduler`.  This seems the safest, and likely could get reused later on.  In addition by supporting it natively we will be able to get even greater benefit when using our threadly schedulers (it will be super clean, though it would be even cleaner if we just removed all of this and used a threadly "Watchdog" instead, but I understand not wanting to add the dependency).

The final commit https://github.com/MariaDB/mariadb-connector-j/commit/ca0acb238c6bf7df8477806a2f85ae25b58cb0b4 addresses an issue I brought up in PR where this structure is not guaranteed to be locked, and may be accessed concurrently.  I solved those couple conditions and added a few comments where those locked assumptions where being made.

As always, all these changes are submitted under the BSD-new license.