### PR TITLE
null Date and Time fields cause NPE

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/queryresults/resultset/MariaSelectResultSet.java
+++ b/src/main/java/org/mariadb/jdbc/internal/queryresults/resultset/MariaSelectResultSet.java
@@ -3253,6 +3253,10 @@ public class MariaSelectResultSet implements ResultSet {
 
 
     private Date binaryDate(byte[] rawBytes, ColumnInformation columnInfo, Calendar cal) throws ParseException {
+        if (rawBytes.length == 0) {
+            return null;
+        }
+        
         switch (columnInfo.getType()) {
             case TIMESTAMP:
             case DATETIME:
@@ -3291,6 +3295,10 @@ public class MariaSelectResultSet implements ResultSet {
     }
 
     private Time binaryTime(byte[] rawBytes, ColumnInformation columnInfo, Calendar cal) throws ParseException {
+        if (rawBytes.length == 0) {
+            return null;
+        }
+        
         switch (columnInfo.getType()) {
             case TIMESTAMP:
             case DATETIME:


### PR DESCRIPTION
Some checks for `rawBytes.length` (like for Timestamp) were missing and caused NPE in MariaSelectResultSet.java in #L3306 and #L3262