### PR TITLE
DatabaseMetaData.getTables() returned "BASE TABLE" as TABLE TYPE

### DIFF
--- a/documentation/Developers-Guide.md
+++ b/documentation/Developers-Guide.md
@@ -34,9 +34,9 @@ You can change those parameter by adding -DdbUrl parameter. like :
  
     mvn test -DdbUrl=jdbc:mariadb://127.0.0.1:3306/testj?user=root&password=*****
     
-You can launch a specific test by adding -Dfile
+You can launch a specific test by adding -Dtest
 
-    mvn test -Dfile=org.mariadb.jdbc.JdbcParserTest
+    mvn test -Dtest=org.mariadb.jdbc.JdbcParserTest
     
 When all test are passing, you can package project.
 Additional tests , like javadoc formatting, code style validation will be done : 

--- a/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
@@ -540,7 +540,7 @@ public class MariaDbDatabaseMetaData implements DatabaseMetaData {
             throws SQLException {
 
         String sql =
-                "SELECT TABLE_SCHEMA TABLE_CAT, NULL  TABLE_SCHEM,  TABLE_NAME, TABLE_TYPE, TABLE_COMMENT REMARKS,"
+                "SELECT TABLE_SCHEMA TABLE_CAT, NULL  TABLE_SCHEM,  TABLE_NAME, IF(TABLE_TYPE='BASE TABLE', 'TABLE', TABLE_TYPE) as TABLE_TYPE, TABLE_COMMENT REMARKS,"
                         + " NULL TYPE_CAT, NULL TYPE_SCHEM, NULL TYPE_NAME, NULL SELF_REFERENCING_COL_NAME, "
                         + " NULL REF_GENERATION"
                         + " FROM INFORMATION_SCHEMA.TABLES "

--- a/src/test/java/org/mariadb/jdbc/DatabaseMetadataTest.java
+++ b/src/test/java/org/mariadb/jdbc/DatabaseMetadataTest.java
@@ -348,6 +348,26 @@ public class DatabaseMetadataTest extends BaseTest {
     }
 
     @Test
+    public void testGetTables3() throws SQLException {
+        Statement stmt = sharedConnection.createStatement();
+        stmt.execute("drop table if exists table_type_test");
+
+        stmt.execute("create table table_type_test (id int not null primary key, "
+                + "val varchar(20)) engine=innodb");
+
+        DatabaseMetaData dbmd = sharedConnection.getMetaData();
+        ResultSet tableSet = dbmd.getTables(null, null, "table_type_test", null);
+
+        assertEquals(true, tableSet.next());
+
+        String tableName = tableSet.getString("TABLE_NAME");
+        assertEquals("table_type_test", tableName);
+        
+        String tableType = tableSet.getString("TABLE_TYPE");
+        assertEquals("TABLE", tableType);	// see for possible values https://docs.oracle.com/javase/7/docs/api/java/sql/DatabaseMetaData.html#getTableTypes%28%29
+    }
+    
+    @Test
     public void testGetColumns() throws SQLException {
         DatabaseMetaData dbmd = sharedConnection.getMetaData();
         ResultSet rs = dbmd.getColumns(null, null, "t1", null);


### PR DESCRIPTION
DatabaseMetaData.getTables() typically returns for  "TABLE TYPES":
"TABLE", "VIEW", "SYSTEM TABLE", "GLOBAL TEMPORARY", "LOCAL TEMPORARY",
"ALIAS", "SYNONYM".

MySQL returns "BASE TABLE" as type for "TABLE" which is noted in MariaDbDatabaseMetaData.mapTableTypes()

Many applications / ORMs expect "TABLE" returned instead of "BASE TABLE"

A test has been added to test for this.

There is also a small correction in the documentation