### PR TITLE
Fixed compatibility issue with old MySQL database (5.0.77)

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
@@ -87,7 +87,7 @@ public class MariaDbDatabaseMetaData implements DatabaseMetaData {
     static String columnTypeClause(String columnName) {
 
         return
-                " UCASE(IF( " + columnName + " LIKE '%(%)%', CONCAT (SUBSTRING( " + columnName + ",1, LOCATE('(',"
+                " UCASE(IF( " + columnName + " LIKE '%(%)%', CONCAT(SUBSTRING( " + columnName + ",1, LOCATE('(',"
                         + columnName + ") - 1 ), SUBSTRING(" + columnName + ",1+locate(')'," + columnName + "))), "
                         + columnName + "))";
     }


### PR DESCRIPTION
Old MySQL doesn't correctly parse "SELECT CONCAT ('a', 'b'); /* extra space after CONCAT */" query. Please, remove space after "CONCAT" function, use "CONCAT(...)" instead. Doesn't affect newer versions od MariaDB and/or MySQL.