### PR TITLE
getTableTypes() returns "TABLE" consistent with getTables()

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
@@ -1779,7 +1779,7 @@ public class MariaDbDatabaseMetaData implements DatabaseMetaData {
 
     public ResultSet getTableTypes() throws SQLException {
         return executeQuery(
-                "SELECT 'BASE TABLE' TABLE_TYPE UNION SELECT 'SYSTEM VIEW' TABLE_TYPE UNION SELECT 'VIEW' TABLE_TYPE");
+                "SELECT 'TABLE' TABLE_TYPE UNION SELECT 'SYSTEM VIEW' TABLE_TYPE UNION SELECT 'VIEW' TABLE_TYPE");
     }
 
     /**


### PR DESCRIPTION
In CONJ-218 (change 4e8c7153e6a7f25128753f2b6527846013e24136), a table type of "BASE TABLE" is translated to "TABLE". The JDBC documentation describes "TABLE" as typical, so that's reasonable.
getTableTypes() returns the set of possible values for table types to be passed as a parameter to getTables() and to be expected in the results from getTables(). It should be modified to match, i.e. it should produce a value of "TABLE" and not "BASE TABLE".