### PR TITLE
Bug fix for wrong salt used when calculating scramble after authentication switch.

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
@@ -543,7 +543,8 @@ public abstract class AbstractConnectProtocol implements Protocol {
                 if (buffer.remaining() > 0) {
                     //AuthSwitchRequest packet.
                     plugin = buffer.readString(Charset.forName("ASCII"));
-                    authData = buffer.readRawBytes(buffer.remaining());
+                    //Skip the null terminator and the end
+                    authData = buffer.readRawBytes(buffer.remaining() - 1);
                 } else {
                     //OldAuthSwitchRequest
                     plugin = DefaultAuthenticationProvider.MYSQL_OLD_PASSWORD;


### PR DESCRIPTION
https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchRequest

The last zero byte should not be included in the salt when re-calculating the scramble responding to auth switch request.

(related issue on JIRA: https://jira.mariadb.org/browse/CONJ-394)