### PR TITLE
Convert password to bytes using UTF-8 charset

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/util/Utils.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/Utils.java
@@ -68,6 +68,7 @@ import javax.net.SocketFactory;
 import java.io.IOException;
 import java.lang.reflect.Proxy;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
@@ -119,7 +120,7 @@ public class Utils {
         }
 
         final MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
-        final byte[] stage1 = messageDigest.digest(password.getBytes());
+        final byte[] stage1 = messageDigest.digest(password.getBytes(StandardCharsets.UTF_8));
         messageDigest.reset();
 
         final byte[] stage2 = messageDigest.digest(stage1);


### PR DESCRIPTION
While exploring mariadb-connector-j an issue was revealed. If one uses a password which contains non-ascii symbols on Windows platform then he fails to establish jdbc connection using maria-connector-j. In source we found that password is converted to bytes using JVM default charset which on Windows is typically Cp1252. So authentication is failed is a result. If JVM is explicitly started with flag _-Dfile.encoding=UTF8_ then authentication completes successfully.