### PR TITLE
Fix support for jdbc:mariadb in java programs that also support jdbc:…

### DIFF
--- a/src/main/java/org/mariadb/jdbc/UrlParser.java
+++ b/src/main/java/org/mariadb/jdbc/UrlParser.java
@@ -153,7 +153,7 @@ public class UrlParser {
             } else {
                 if (url.startsWith("jdbc:mariadb:")) {
                     UrlParser urlParser = new UrlParser();
-                    parseInternal(urlParser, "jdbc:mysql:" + url.substring(13), prop);
+                    parseInternal(urlParser, url, prop);
                     return urlParser;
                 }
 


### PR DESCRIPTION
…mysql

It can get confusing in other java programs which support jdbc:mysql for the mysql connector but then want to support jdbc:mariadb for the mariadb connector. This fixes a use case for gerrit where we need to support jdbc:mysql for the mysql connector but want to support jdbc:mariadb to allow us to use session variables to support utf8mb4 and utf8mb4_unicode_gi. Tested locally and fixes it for us. This should not cause any breakages.

This will also be used in conjunction with https://github.com/MariaDB/mariadb-connector-j/pull/97