### PR TITLE
CONJ-426 Allow executeBatch to be interrupted

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractMultiSend.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractMultiSend.java
@@ -269,6 +269,10 @@ public abstract class AbstractMultiSend {
                     }
                     throw new QueryException("Error reading results " + executionException.getCause().getMessage());
                 } catch (InterruptedException interruptedException) {
+                    futureReadTask.cancel(true);
+
+                    Thread.currentThread().interrupt();
+                    throw new QueryException("Interrupted awaiting response", -1, INTERRUPTED_EXCEPTION.getSqlState(), interruptedException);
                 } finally {
                     //bulk can prepare, and so if prepare cache is enable, can replace an already cached prepareStatement
                     //this permit to release those old prepared statement without conflict.

--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractQueryProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractQueryProtocol.java
@@ -1000,6 +1000,10 @@ public class AbstractQueryProtocol extends AbstractConnectProtocol implements Pr
      * @throws QueryException if sub-result connection fail
      */
     public void readPacket(Results results) throws QueryException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new QueryException("Interrupted while reading", -1, INTERRUPTED_EXCEPTION.getSqlState());
+        }
+
         Buffer buffer;
         try {
             buffer = packetFetcher.getReusableBuffer();

--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AsyncMultiRead.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AsyncMultiRead.java
@@ -79,11 +79,6 @@ public class AsyncMultiRead implements Callable<AsyncMultiReadResult> {
 
         //read all corresponding results
         for (int counter = 0; counter < nbResult; counter++) {
-            if (Thread.currentThread().isInterrupted()) {
-                asyncMultiReadResult.setException(new QueryException("Interrupted reading responses", -1, INTERRUPTED_EXCEPTION.getSqlState()));
-                break;
-            }
-
             try {
                 protocol.getResult(results);
             } catch (QueryException qex) {

--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AsyncMultiRead.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AsyncMultiRead.java
@@ -9,6 +9,8 @@ import org.mariadb.jdbc.internal.util.dao.QueryException;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import static org.mariadb.jdbc.internal.util.SqlStates.INTERRUPTED_EXCEPTION;
+
 public class AsyncMultiRead implements Callable<AsyncMultiReadResult> {
 
     private final ComStmtPrepare comStmtPrepare;
@@ -77,6 +79,11 @@ public class AsyncMultiRead implements Callable<AsyncMultiReadResult> {
 
         //read all corresponding results
         for (int counter = 0; counter < nbResult; counter++) {
+            if (Thread.currentThread().isInterrupted()) {
+                asyncMultiReadResult.setException(new QueryException("Interrupted reading responses", -1, INTERRUPTED_EXCEPTION.getSqlState()));
+                break;
+            }
+
             try {
                 protocol.getResult(results);
             } catch (QueryException qex) {

--- a/src/test/java/org/mariadb/jdbc/ExecuteBatchTest.java
+++ b/src/test/java/org/mariadb/jdbc/ExecuteBatchTest.java
@@ -58,7 +58,7 @@ public class ExecuteBatchTest extends BaseTest {
                     PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO ExecuteBatchTest(test, test2) values (?, ?)");
 
                     // Send a large enough batch that will take long enough to allow us to interrupt it
-                    for (int i = 0; i < 50_000; i++) {
+                    for (int i = 0; i < 1_000_000; i++) {
                         preparedStatement.setString(1, String.valueOf(System.nanoTime()));
                         preparedStatement.setInt(2, i);
                         preparedStatement.addBatch();
@@ -84,7 +84,7 @@ public class ExecuteBatchTest extends BaseTest {
         barrier.await();
 
         // Allow the query time to send
-        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+        Thread.sleep(500);
 
         // Interrupt the thread
         service.shutdownNow();
@@ -92,6 +92,8 @@ public class ExecuteBatchTest extends BaseTest {
         Assert.assertTrue(
             service.awaitTermination(1, TimeUnit.MINUTES)
         );
+
+        Assert.assertTrue(wasInterrupted.get());
 
         Assert.assertNotNull(exceptionRef.get());
 
@@ -102,9 +104,6 @@ public class ExecuteBatchTest extends BaseTest {
             "Exception should be a SQLException: \n" + writer.toString(),
             exceptionRef.get() instanceof SQLException
         );
-
-        Assert.assertTrue(wasInterrupted.get());
-
     }
 
     @Test

--- a/src/test/java/org/mariadb/jdbc/ExecuteBatchTest.java
+++ b/src/test/java/org/mariadb/jdbc/ExecuteBatchTest.java
@@ -45,6 +45,8 @@ public class ExecuteBatchTest extends BaseTest {
      */
     @Test
     public void interruptExecuteBatch() throws Exception {
+        Assume.assumeTrue(sharedBulkCapacity());
+
         ExecutorService service = Executors.newFixedThreadPool(1);
 
         final CyclicBarrier barrier = new CyclicBarrier(2);


### PR DESCRIPTION
@rusher this PR attempts to address the issue identified in https://jira.mariadb.org/browse/CONJ-426

I believe that the cause of this that [AbstractMultiSend#executeBatchStandard](https://github.com/MariaDB/mariadb-connector-j/blob/master/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractMultiSend.java#L271) swallows the `InterruptedException` and does not reset the threads interrupted status.  Thus the caller thread has no idea whether its been interrupted or not.

The `executeBatch` call returns early due to the interrupt but the query is actually running the background.  Thus there is a race condition when querying the state of the `cmdInformation` in `[MariaDbServerPreparedStatement#executeBatch](https://github.com/MariaDB/mariadb-connector-j/blob/master/src/main/java/org/mariadb/jdbc/MariaDbServerPreparedStatement.java#L276).  This manifests as the NPE that I linked in the ticket.

My fix in this PR addresses all of this by modifying `AsyncMultiSend` to properly catch the `InterruptedException`, reset the thread interrupt state and rethrow the exception as a `QueryException`.  I also modified this class to cancel the ongoing `AsyncMultiRead` task which is also now interruptible.

I've also modified the data structures in `CmdInformationMultiple` to be thread safe since there is still a tiny chance that the `AsyncMultiRead` task will attempt to write a result while the caller thread in `MariaDbServerPreparedStatement` will attempt to query them.