### PR TITLE
Retain leading slash when trust store beings with 'file:///'

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/protocol/tls/MariaDbX509TrustManager.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/tls/MariaDbX509TrustManager.java
@@ -99,7 +99,6 @@ public class MariaDbX509TrustManager implements X509TrustManager {
                     String trustStore = options.trustStore;
 
                     //permit using "file:..." for compatibility
-                    if (trustStore.startsWith("file:///")) trustStore = trustStore.substring(8);
                     if (trustStore.startsWith("file://")) trustStore = trustStore.substring(7);
                     inStream = new FileInputStream(trustStore);
 


### PR DESCRIPTION
Removing 8 characters in the case of a file path that starts with 'file:///' removes the leading slash. This causes an error as the connector will assume you have provided a relative file path. 