### PR TITLE
ignore UNSIGNED mark in TINYINT(1) columns when TINYINT1_IS_BIT is set

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
@@ -91,7 +91,7 @@ public class MariaDbDatabaseMetaData implements DatabaseMetaData {
                 + "COLUMN_TYPE))";
 
         if ((dataTypeMappingFlags & MariaSelectResultSet.TINYINT1_IS_BIT) > 0) {
-            upperCaseWithoutSize = " IF(COLUMN_TYPE = 'tinyint(1)', 'BIT', " + upperCaseWithoutSize + ")";
+            upperCaseWithoutSize = " IF(COLUMN_TYPE like 'tinyint(1)%', 'BIT', " + upperCaseWithoutSize + ")";
         }
 
         if ((dataTypeMappingFlags & MariaSelectResultSet.YEAR_IS_DATE_TYPE) == 0) {
@@ -412,7 +412,7 @@ public class MariaDbDatabaseMetaData implements DatabaseMetaData {
                         + " WHEN 'timestamp' THEN " + Types.TIMESTAMP
                         + " WHEN 'tinyint' THEN "
                         + (((connection.getProtocol().getDataTypeMappingFlags() & MariaSelectResultSet.TINYINT1_IS_BIT) == 0)
-                        ? Types.TINYINT : "IF(" + fullTypeColumnName + "='tinyint(1)'," + Types.BIT + "," + Types.TINYINT + ") ")
+                        ? Types.TINYINT : "IF(" + fullTypeColumnName + " like 'tinyint(1)%'," + Types.BIT + "," + Types.TINYINT + ") ")
                         + " WHEN 'year' THEN "
                         + (((connection.getProtocol().getDataTypeMappingFlags() & MariaSelectResultSet.YEAR_IS_DATE_TYPE) == 0)
                         ? Types.SMALLINT : Types.DATE)


### PR DESCRIPTION
Proposed fix for issue https://jira.mariadb.org/browse/CONJ-455

Please note that this is my first pull request for a fix so do double check it doesn't crash anything.

(I'm contributing the code of this whole pull request under the BSD-new license.)