### PR TITLE
* fixed issue #CONJ-489

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaXaResource.java
+++ b/src/main/java/org/mariadb/jdbc/MariaXaResource.java
@@ -68,11 +68,11 @@ public class MariaXaResource implements XAResource {
     }
 
     static String xidToString(Xid xid) {
-        StringBuffer sb = new StringBuffer(2 * Xid.MAXBQUALSIZE + 2 * Xid.MAXGTRIDSIZE + 16);
+        StringBuilder sb = new StringBuilder(2 * Xid.MAXBQUALSIZE + 2 * Xid.MAXGTRIDSIZE + 16);
         sb.append("0x")
-                .append(Utils.hexdump(Integer.MAX_VALUE, 0, xid.getGlobalTransactionId()))
+                .append(Utils.byteArrayToHexString(xid.getGlobalTransactionId()))
                 .append(",0x")
-                .append(Utils.hexdump(Integer.MAX_VALUE, 0, xid.getBranchQualifier()))
+                .append(Utils.byteArrayToHexString(xid.getBranchQualifier()))
                 .append(",").append(xid.getFormatId());
         return sb.toString();
     }

--- a/src/main/java/org/mariadb/jdbc/internal/util/Utils.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/Utils.java
@@ -704,4 +704,16 @@ public class Utils {
         }
     }
 
+    protected static String getHex(final byte[] raw) {
+        final StringBuilder hex = new StringBuilder(2 * raw.length);
+        for (final byte b : raw) {
+            hex.append(hexArray[(b & 0xF0) >> 4])
+                    .append(hexArray[(b & 0x0F)]);
+        }
+        return hex.toString();
+    }    
+    
+    public static String byteArrayToHexString(final byte[] bytes) {
+        return (bytes != null) ? getHex(bytes) : "";
+    }    
 }


### PR DESCRIPTION
This fixed issue CONJ-489.

Caused by: javax.transaction.xa.XAException: (conn:41252) You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '0x
	at org.mariadb.jdbc.MariaXaResource.mapXaException(MariaXaResource.java:123)
	at org.mariadb.jdbc.MariaXaResource.execute(MariaXaResource.java:137)
	at org.mariadb.jdbc.MariaXaResource.start(MariaXaResource.java:314)
	at com.atomikos.datasource.xa.XAResourceTransaction.resume(XAResourceTransaction.java:297)

The hexdump implementation is creating an XA statement as followed:

XA PREPARE  0x 31 39 32 2E 31 36 38 2E  32 35 31 2E 32 2E 74 6D     192.168.251.2.tm
31 34 39 36 36 30 31 31  37 38 38 32 35 30 32 35     1496601178825025
34 31                                                41
,0x
31 39 32 2E 31 36 38 2E  32 35 31 2E 32 2E 74 6D     192.168.251.2.tm
32 30 34 37                                          2047
,1096044365

This leads to an exception.

The provided implementation is corresponding to the mysql implementation or atomikos implementation.
 The result would be:

XA PREPARE 0x3139322E3136382E3235312E322E746D313439363630313137383832353032353431,0x3139322E3136382E3235312E322E746D32303437,1096044365