### PR TITLE
Improve MariaDB driver stability in case JNA errors

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/util/PidFactory.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/PidFactory.java
@@ -114,7 +114,7 @@ public class PidFactory {
 
                             }
                         }
-                    } catch (Exception cle) {
+                    } catch (Throwable cle) {
                         //jna jar's are not in classpath, no PID returned
                     }
 


### PR DESCRIPTION
Having MariaDB driver 1.5.9 on Debian 7 x86-64 we've added JNA 4.4.0 to project dependencies and got the following error:
```
java.lang.UnsatisfiedLinkError: /tmp/jna--1686123082/jna7903308312970639264.tmp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.14' not found (required by /tmp/jna--1686123082/jna7903308312970639264.tmp)
	at java.lang.ClassLoader$NativeLibrary.load(Native Method)
	at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1941)
	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1824)
	at java.lang.Runtime.load0(Runtime.java:809)
	at java.lang.System.load(System.java:1086)
	at com.sun.jna.Native.loadNativeDispatchLibraryFromClasspath(Native.java:947)
	at com.sun.jna.Native.loadNativeDispatchLibrary(Native.java:922)
	at com.sun.jna.Native.<clinit>(Native.java:190)
	at org.mariadb.jdbc.internal.util.PidFactory$CLibrary.<clinit>(PidFactory.java:137)
	at org.mariadb.jdbc.internal.util.PidFactory$1.getPid(PidFactory.java:87)
	at org.mariadb.jdbc.internal.packet.send.SendHandshakeResponsePacket.writeConnectAttributes(SendHandshakeResponsePacket.java:215)
	at org.mariadb.jdbc.internal.packet.send.SendHandshakeResponsePacket.send(SendHandshakeResponsePacket.java:201)
	at org.mariadb.jdbc.internal.protocol.AbstractConnectProtocol.authentication(AbstractConnectProtocol.java:531)
	at org.mariadb.jdbc.internal.protocol.AbstractConnectProtocol.handleConnectionPhases(AbstractConnectProtocol.java:503)
	at org.mariadb.jdbc.internal.protocol.AbstractConnectProtocol.connect(AbstractConnectProtocol.java:382)
	at org.mariadb.jdbc.internal.protocol.AbstractConnectProtocol.connectWithoutProxy(AbstractConnectProtocol.java:839)
	at org.mariadb.jdbc.internal.util.Utils.retrieveProxy(Utils.java:479)
	at org.mariadb.jdbc.Driver.connect(Driver.java:104)
	at java.sql.DriverManager.getConnection(DriverManager.java:664)
	at java.sql.DriverManager.getConnection(DriverManager.java:247)
```
It turned out to be a compatiblity issue in recent JNA versions (4.3.0 and 4.4.0) - https://github.com/java-native-access/jna/issues/853. 

The change wasn't really connected with MariaDB driver and PID functionality causing the exception seems to be optional (as well as use of JNA), nevertheless it failed the whole thing.

After looking into the code, it seems that mere catch `Throwable` instead of `Exception` (like it's already done for Windows part of `PidFactory`) covers cases like `UnsatisfiedLinkError` thrown from JNA and makes such failures just minor issues.