### PR TITLE
Fix typo in "Connection is close(d)"'

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractQueryProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractQueryProtocol.java
@@ -1657,7 +1657,7 @@ public class AbstractQueryProtocol extends AbstractConnectProtocol implements Pr
             activeFutureTask = null;
         }
 
-        if (!this.connected) throw new SQLException("Connection is close", "08000", 1220);
+        if (!this.connected) throw new SQLException("Connection is closed", "08000", 1220);
         interrupted = false;
 
     }


### PR DESCRIPTION
Typo in commit d6581e89d9c686bf7a01ec72005ef0653da5bd88