### PR TITLE
CONJ-541 resultSet.relative() behavior is incorrect when crossing result set boundaries

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/SelectResultSet.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/SelectResultSet.java
@@ -861,11 +861,16 @@ public class SelectResultSet implements ResultSet {
             throw new SQLException("Invalid operation for result set type TYPE_FORWARD_ONLY");
         }
         int newPos = rowPointer + rows;
-        if (newPos > -1 && newPos <= dataSize) {
+        if ( newPos <= -1 ) {
+            rowPointer = -1;
+            return false;
+        } else if ( newPos >= dataSize ) {
+            rowPointer = dataSize;
+            return false;
+        } else {
             rowPointer = newPos;
             return true;
         }
-        return false;
     }
 
     @Override

--- a/src/test/java/org/mariadb/jdbc/DriverTest.java
+++ b/src/test/java/org/mariadb/jdbc/DriverTest.java
@@ -668,6 +668,7 @@ public class DriverTest extends BaseTest {
         rs.relative(-3);
         assertEquals(1, rs.getInt(1));
         assertEquals(false, rs.relative(-1));
+        rs.next();
         assertEquals(1, rs.getInt(1));
         rs.last();
         assertEquals(4, rs.getInt(1));

--- a/src/test/java/org/mariadb/jdbc/ResultSetTest.java
+++ b/src/test/java/org/mariadb/jdbc/ResultSetTest.java
@@ -440,6 +440,39 @@ public class ResultSetTest extends BaseTest {
         rs.close();
     }
 
+    @Test
+    public void relativeBackwardTest() throws SQLException {
+        insertRows(3);
+        Statement stmt = sharedConnection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+        ResultSet rs = stmt.executeQuery("SELECT * FROM result_set_test");
+        rs.afterLast();
+        assertFalse(rs.isBeforeFirst());
+        assertFalse(rs.isFirst());
+        assertFalse(rs.isLast());
+        assertTrue(rs.isAfterLast());
+
+        assertTrue(rs.relative(-2));
+        assertFalse(rs.isBeforeFirst());
+        assertFalse(rs.isFirst());
+        assertFalse(rs.isLast());
+        assertFalse(rs.isAfterLast());
+
+        assertTrue(rs.relative(-1));
+        assertFalse(rs.isBeforeFirst());
+        assertTrue(rs.isFirst());
+        assertFalse(rs.isLast());
+        assertFalse(rs.isAfterLast());
+
+        assertFalse(rs.relative(-1));
+        assertTrue(rs.isBeforeFirst());
+        assertFalse(rs.isFirst());
+        assertFalse(rs.isLast());
+        assertFalse(rs.isAfterLast());
+
+        assertFalse(rs.previous());
+        rs.close();
+    }
+
     private void insertRows(int numberOfRowsToInsert) throws SQLException {
         sharedConnection.createStatement().execute("truncate result_set_test ");
         for (int i = 1; i <= numberOfRowsToInsert; i++) {

--- a/src/test/java/org/mariadb/jdbc/ResultSetTest.java
+++ b/src/test/java/org/mariadb/jdbc/ResultSetTest.java
@@ -408,6 +408,38 @@ public class ResultSetTest extends BaseTest {
         }
     }
 
+    @Test
+    public void relativeForwardTest() throws SQLException {
+        insertRows(3);
+        Statement stmt = sharedConnection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+        ResultSet rs = stmt.executeQuery("SELECT * FROM result_set_test");
+        assertTrue(rs.isBeforeFirst());
+        assertFalse(rs.isFirst());
+        assertFalse(rs.isLast());
+        assertFalse(rs.isAfterLast());
+
+        assertTrue(rs.relative(2));
+        assertFalse(rs.isBeforeFirst());
+        assertFalse(rs.isFirst());
+        assertFalse(rs.isLast());
+        assertFalse(rs.isAfterLast());
+
+        assertTrue(rs.relative(1));
+        assertFalse(rs.isBeforeFirst());
+        assertFalse(rs.isFirst());
+        assertTrue(rs.isLast());
+        assertFalse(rs.isAfterLast());
+
+        assertFalse(rs.relative(1));
+        assertFalse(rs.isBeforeFirst());
+        assertFalse(rs.isFirst());
+        assertFalse(rs.isLast());
+        assertTrue(rs.isAfterLast());
+
+        assertFalse(rs.next());
+        rs.close();
+    }
+
     private void insertRows(int numberOfRowsToInsert) throws SQLException {
         sharedConnection.createStatement().execute("truncate result_set_test ");
         for (int i = 1; i <= numberOfRowsToInsert; i++) {


### PR DESCRIPTION
This PR changes the behavior of `resultSet.relative()` when crossing result set boundaries in order to conform to the `java.sql.ResultSet#relative` javadoc.

One existing test, `DriverTest#testResultSetPositions`, had to be altered because it relied on an incorrect behavior (expected `relative(-1)` from the first row to not change the position).