### PR TITLE
Check that getMoreResults returns false

### DIFF
--- a/src/test/java/org/mariadb/jdbc/CallStatementTest.java
+++ b/src/test/java/org/mariadb/jdbc/CallStatementTest.java
@@ -172,6 +172,7 @@ public class CallStatementTest extends BaseTest {
         assertTrue(rs.next());
         assertEquals(2, rs.getInt(1));
         assertFalse(rs.next());
+        assertFalse(stmt.getMoreResults());
     }
 
     @Test
@@ -187,6 +188,7 @@ public class CallStatementTest extends BaseTest {
         assertTrue(rs.next());
         assertEquals(2, rs.getInt(1));
         assertFalse(rs.next());
+        assertFalse(stmt.getMoreResults());
     }
 
     @Test


### PR DESCRIPTION
Testing that stmt.getMoreResults() returns false fails with the current version showing that there's a bug which causes us some problems.
I created a JIRA bug report CONJ-542 for this.