### PR TITLE
Fix enabling logging in an OSGi environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
                             <Bundle-SymbolicName>org.mariadb.jdbc</Bundle-SymbolicName>
                             <Export-Package>org.mariadb.jdbc</Export-Package>
                             <Import-Package>
-                                javax.net;resolution:=optional,javax.net.ssl;resolution:=optional,javax.sql;resolution:=optional,javax.transaction.xa;resolution:=optional
+                                javax.net;resolution:=optional,javax.net.ssl;resolution:=optional,javax.sql;resolution:=optional,javax.transaction.xa;resolution:=optional,org.slf4j;resolution:=optional
                             </Import-Package>
                         </manifestEntries>
                     </archive>


### PR DESCRIPTION
Currently, within an OSGi environment (such as apache karaf e.g.), when logging is requested through configuration, enabling it will fail inside LoggerFactory with "Logging cannot be activated, missing slf4j dependency" always.
This is due to the fact that the OSGi Metadata you already generate is incorrect/missing something.
This commit fixes this "Import-Package" statement by adding the org.slf4j package as an optional import package.

Please consider adopting this (rather simple) fix and release a bugfix because right now we use a locally "fixed" version instead of the official one.