### PR TITLE
[CONJ-564] Never ever throw an instance of java.lang.Error

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbBlob.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbBlob.java
@@ -82,7 +82,7 @@ public class MariaDbBlob implements Blob, Serializable {
      */
     public MariaDbBlob(byte[] bytes) {
         if (bytes == null) {
-            throw new AssertionError("byte array is null");
+            throw new NullPointerException("byte array is null");
         }
         data = bytes;
         offset = 0;
@@ -98,7 +98,7 @@ public class MariaDbBlob implements Blob, Serializable {
      */
     public MariaDbBlob(byte[] bytes, int offset, int length) {
         if (bytes == null) {
-            throw new AssertionError("byte array is null");
+            throw new NullPointerException("byte array is null");
         }
         data = bytes;
         this.offset = offset;

--- a/src/main/java/org/mariadb/jdbc/MariaDbClob.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbClob.java
@@ -55,6 +55,7 @@ package org.mariadb.jdbc;
 import org.mariadb.jdbc.internal.util.exceptions.ExceptionMapper;
 
 import java.io.*;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Clob;
 import java.sql.NClob;
@@ -96,11 +97,7 @@ public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializabl
      * @return string value of blob content.
      */
     public String toString() {
-        try {
-            return new String(data, offset, length, StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            throw new AssertionError(e);
-        }
+        return new String(data, offset, length, StandardCharsets.UTF_8);
     }
 
     /**
@@ -191,7 +188,7 @@ public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializabl
             if (byteValue < 0x80) {
                 pos += 1;
             } else if (byteValue < 0xC2) {
-                throw new AssertionError("invalid UTF8");
+                throw new UncheckedIOException("invalid UTF8",new CharacterCodingException());
             } else if (byteValue < 0xE0) {
                 pos += 2;
             } else if (byteValue < 0xF0) {
@@ -199,7 +196,7 @@ public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializabl
             } else if (byteValue < 0xF8) {
                 pos += 4;
             } else {
-                throw new AssertionError("invalid UTF8");
+                throw new UncheckedIOException("invalid UTF8",new CharacterCodingException());
             }
         }
         return pos;
@@ -238,7 +235,7 @@ public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializabl
             if (byteValue < 0x80) {
                 i += 1;
             } else if (byteValue < 0xC2) {
-                throw new AssertionError("invalid UTF8");
+                throw new UncheckedIOException("invalid UTF8",new CharacterCodingException());
             } else if (byteValue < 0xE0) {
                 i += 2;
             } else if (byteValue < 0xF0) {
@@ -246,7 +243,7 @@ public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializabl
             } else if (byteValue < 0xF8) {
                 i += 4;
             } else {
-                throw new AssertionError("invalid UTF8");
+                throw new UncheckedIOException("invalid UTF8",new CharacterCodingException());
             }
             len++;
         }
@@ -261,7 +258,7 @@ public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializabl
             if (byteValue < 0x80) {
                 pos += 1;
             } else if (byteValue < 0xC2) {
-                throw new AssertionError("invalid UTF8");
+                throw new UncheckedIOException("invalid UTF8",new CharacterCodingException());
             } else if (byteValue < 0xE0) {
                 pos += 2;
             } else if (byteValue < 0xF0) {
@@ -269,7 +266,7 @@ public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializabl
             } else if (byteValue < 0xF8) {
                 pos += 4;
             } else {
-                throw new AssertionError("invalid UTF8");
+                throw new UncheckedIOException("invalid UTF8",new CharacterCodingException());
             }
         }
         length = pos - offset;

--- a/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
@@ -399,7 +399,7 @@ public class MariaDbDatabaseMetaData implements DatabaseMetaData {
                 return DatabaseMetaData.importedKeyRestrict;
 
             default:
-                throw new AssertionError("should not happen");
+                throw new IllegalArgumentException("Illegal key action '" + actionKey + "' specified.");
         }
     }
 

--- a/src/main/java/org/mariadb/jdbc/internal/com/send/gssapi/StandardGssapiAuthentication.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/send/gssapi/StandardGssapiAuthentication.java
@@ -92,7 +92,7 @@ public class StandardGssapiAuthentication extends GssapiAuth {
                 }
                 jaasConfFile.deleteOnExit();
             } catch (final IOException ex) {
-                throw new IOError(ex);
+                throw new UncheckedIOException(ex);
             }
 
             System.setProperty("java.security.auth.login.config", jaasConfFile.getCanonicalPath());


### PR DESCRIPTION
Replace Exceptions based on java.lang.Error by likewise java.lang.RuntimeException replacements.