### PR TITLE
[CONJ-384] support useAffectedRows

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
@@ -863,11 +863,17 @@ public abstract class AbstractConnectProtocol implements Protocol {
                 | MariaDbServerCapabilities.LOCAL_FILES
                 | MariaDbServerCapabilities.MULTI_RESULTS
                 | MariaDbServerCapabilities.PS_MULTI_RESULTS
-                | MariaDbServerCapabilities.FOUND_ROWS
                 | MariaDbServerCapabilities.PLUGIN_AUTH
                 | MariaDbServerCapabilities.CONNECT_ATTRS
                 | MariaDbServerCapabilities.PLUGIN_AUTH_LENENC_CLIENT_DATA
                 | MariaDbServerCapabilities.CLIENT_SESSION_TRACK;
+
+        // MySQL/MariaDB has two ways of calculating row count, eg for an UPDATE statement.
+        // The default (and JDBC standard) is "found rows". The other option is "affected rows".
+        // See https://jira.mariadb.org/browse/CONJ-384
+        if (!options.useAffectedRows) {
+            capabilities |= MariaDbServerCapabilities.FOUND_ROWS;
+        }
 
         if (options.allowMultiQueries || (options.rewriteBatchedStatements)) {
             capabilities |= MariaDbServerCapabilities.MULTI_STATEMENTS;

--- a/src/main/java/org/mariadb/jdbc/internal/util/DefaultOptions.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/DefaultOptions.java
@@ -533,7 +533,14 @@ public enum DefaultOptions {
      * On master/slave configuration, permit to connect Connection defaulting to a slave
      * when master is down.
      */
-    ALLOW_MASTER_DOWN("allowMasterDownConnection", Boolean.FALSE, "2.2.0");
+    ALLOW_MASTER_DOWN("allowMasterDownConnection", Boolean.FALSE, "2.2.0"),
+
+    /**
+     * If false (default), use "found rows" for the row count of statements. This corresponds to the JDBC standard.
+     * If true, use "affected rows" for the row count.
+     * This changes the behavior of, for example, UPDATE... ON DUPLICATE KEY statements.
+     */
+    USEAFFECTEDROWS("useAffectedRows", Boolean.FALSE, "2.2.2");
 
 
 

--- a/src/main/java/org/mariadb/jdbc/internal/util/Options.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/Options.java
@@ -107,6 +107,7 @@ public class Options implements Cloneable {
     public int prepStmtCacheSize = 250;
     public int prepStmtCacheSqlLimit = 2048;
     public boolean useLegacyDatetimeCode = true;
+    public boolean useAffectedRows;
     public boolean maximizeMysqlCompatibility;
     public boolean useServerPrepStmts;
     public boolean continueBatchOnError = true;
@@ -203,6 +204,7 @@ public class Options implements Cloneable {
         if (allowLocalInfile != opt.allowLocalInfile) return false;
         if (cachePrepStmts != opt.cachePrepStmts) return false;
         if (useLegacyDatetimeCode != opt.useLegacyDatetimeCode) return false;
+        if (useAffectedRows != opt.useAffectedRows) return false;
         if (maximizeMysqlCompatibility != opt.maximizeMysqlCompatibility) return false;
         if (useServerPrepStmts != opt.useServerPrepStmts) return false;
         if (continueBatchOnError != opt.continueBatchOnError) return false;
@@ -326,6 +328,7 @@ public class Options implements Cloneable {
         result = 31 * result + prepStmtCacheSize;
         result = 31 * result + prepStmtCacheSqlLimit;
         result = 31 * result + (useLegacyDatetimeCode ? 1 : 0);
+        result = 31 * result + (useAffectedRows ? 1 : 0);
         result = 31 * result + (maximizeMysqlCompatibility ? 1 : 0);
         result = 31 * result + (useServerPrepStmts ? 1 : 0);
         result = 31 * result + (continueBatchOnError ? 1 : 0);


### PR DESCRIPTION
Adds support for the useAffectedRows JDBC URL parameter.

This is important for anyone who needs to run `UPDATE` statements and know, afterward, whether anything changed. (As opposed to learning only how many rows were matched.)

**Travis test:** https://travis-ci.org/dcposch/mariadb-connector-j/builds/335880775

I've tested functionality locally. Let me know if there's an easy way to add an integration test.

@rusher 