### PR TITLE
Take maxFieldSize only if length is larger.

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/rowprotocol/BinaryRowProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/rowprotocol/BinaryRowProtocol.java
@@ -275,7 +275,7 @@ public class BinaryRowProtocol extends RowProtocol {
         switch (columnInfo.getColumnType()) {
             case STRING:
                 if (getMaxFieldSize() > 0) {
-                    return new String(buf, pos, Math.max(getMaxFieldSize() * 3, length), StandardCharsets.UTF_8)
+                    return new String(buf, pos, Math.min(getMaxFieldSize() * 3, length), StandardCharsets.UTF_8)
                             .substring(0, getMaxFieldSize());
                 }
                 return new String(buf, pos, length, StandardCharsets.UTF_8);
@@ -325,7 +325,7 @@ public class BinaryRowProtocol extends RowProtocol {
                 return null;
             default:
                 if (getMaxFieldSize() > 0) {
-                    return new String(buf, pos, Math.max(getMaxFieldSize() * 3, length), StandardCharsets.UTF_8)
+                    return new String(buf, pos, Math.min(getMaxFieldSize() * 3, length), StandardCharsets.UTF_8)
                             .substring(0, getMaxFieldSize());
                 }
                 return new String(buf, pos, length, StandardCharsets.UTF_8);

--- a/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/rowprotocol/TextRowProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/rowprotocol/TextRowProtocol.java
@@ -220,7 +220,7 @@ public class TextRowProtocol extends RowProtocol {
         }
 
         if (maxFieldSize > 0) {
-            return new String(buf, pos, Math.max(maxFieldSize * 3, length), StandardCharsets.UTF_8)
+            return new String(buf, pos, Math.min(maxFieldSize * 3, length), StandardCharsets.UTF_8)
                     .substring(0, maxFieldSize);
         }
 


### PR DESCRIPTION
Enforcing maxFieldSize in BinaryRowProtocol and TextRowProtocol is quite obviously broken. This pull request fixes the brokenness.