### PR TITLE
return a real row number from a result set in case of streaming too

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/SelectResultSet.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/SelectResultSet.java
@@ -764,7 +764,7 @@ public class SelectResultSet implements ResultSet {
     @Override
     public int getRow() throws SQLException {
         checkClose();
-        if (streaming) {
+        if (streaming && resultSetScrollType == TYPE_FORWARD_ONLY) {
             return 0;
         }
         return rowPointer + 1;

--- a/src/test/java/org/mariadb/jdbc/DriverTest.java
+++ b/src/test/java/org/mariadb/jdbc/DriverTest.java
@@ -96,6 +96,7 @@ public class DriverTest extends BaseTest {
         createTable("quotesPreparedStatements", "id int not null primary key auto_increment, a varchar(10) , "
                 + "b varchar(10)");
         createTable("ressetpos", "i int not null primary key", "engine=innodb");
+        createTable("streamingressetpos", "i int not null primary key", "engine=innodb");
         createTable("streamingtest", "val varchar(20)");
         createTable("testBlob2", "a blob");
         createTable("testString2", "a varchar(10)");
@@ -690,6 +691,26 @@ public class DriverTest extends BaseTest {
         rs.absolute(-1);
         assertEquals(4, rs.getRow());
         assertEquals(4, rs.getInt(1));
+    }
+
+    @Test
+    public void streamingResultSetPositions() throws SQLException {
+        sharedConnection.createStatement().execute("INSERT INTO streamingressetpos VALUES (1), (2), (3), (4)");
+        Statement stmt = sharedConnection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+        stmt.setFetchSize(Integer.MIN_VALUE);
+        ResultSet rs = stmt.executeQuery("SELECT * FROM streamingressetpos");
+        assertTrue(rs.absolute(2));
+        assertEquals(2, rs.getRow());
+        assertTrue(rs.relative(-1));
+        assertEquals(1, rs.getRow());
+        rs.afterLast();
+        assertEquals(5, rs.getRow());
+        rs.beforeFirst();
+        assertEquals(0, rs.getRow());
+        assertTrue(rs.next());
+        assertEquals(1, rs.getRow());
+        assertTrue(rs.next());
+        assertEquals(2, rs.getRow());
     }
 
     @Test(expected = SQLException.class)


### PR DESCRIPTION
According to jdbc specification ResultSet.getRow() method must return current row number in all cases except it has TYPE_FORWARD_ONLY type.

It seems like there is no reason to return 0 in case of streaming except the ResultSet has TYPE_FORWARD_ONLY type. If streaming is true and result set has a type different from TYPE_FORWARD_ONLY then the rowPointer always contains real current row number - 1.