### PR TITLE
NPE fix if url used like: jdbc:mariadb://localhost/testj?user=root&maxPoolSize=10

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbPoolDataSource.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbPoolDataSource.java
@@ -150,7 +150,7 @@ public class MariaDbPoolDataSource implements DataSource, XADataSource, Closeabl
      * @return the port number
      */
     public int getPort() {
-        if (port!=null && port != 0) return port;
+        if (port != null && port != 0) return port;
         return urlParser != null ? urlParser.getHostAddresses().get(0).port : 3306;
     }
 

--- a/src/main/java/org/mariadb/jdbc/MariaDbPoolDataSource.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbPoolDataSource.java
@@ -150,7 +150,7 @@ public class MariaDbPoolDataSource implements DataSource, XADataSource, Closeabl
      * @return the port number
      */
     public int getPort() {
-        if (port != 0) return port;
+        if (port!=null && port != 0) return port;
         return urlParser != null ? urlParser.getHostAddresses().get(0).port : 3306;
     }
 


### PR DESCRIPTION
//Sample Program to create NullPointerException:

public class ConnectionUsingDS {
    public static void main(String args[]) throws SQLException {
        MariaDbPoolDataSource pool =
                new MariaDbPoolDataSource("jdbc:mariadb://localhost/testj?user=root&maxPoolSize=10");
        try (Connection conn = pool.getConnection()) {
            try(Statement stmt = conn.createStatement()){
                ResultSet rs = stmt.executeQuery("select 'Hello World!'");
                while(rs.next()){
                    System.out.println(rs.getString(1));
                }
               System.out.println(pool.getDatabaseName() +", "+pool.getPort());
            }
        }

    }
}
//Output: 
//Hello World!
//Exception in thread "main" java.lang.NullPointerException
//	at org.mariadb.jdbc.MariaDbPoolDataSource.getPort(MariaDbPoolDataSource.java:153)
//	at mariadb.test.connection.ConnectionUsingDS.main(ConnectionUsingDS.java:32)