### PR TITLE
[misc] enabled running  of 'SHOW ENGINE INNODB STATUS' for error code 1213

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/util/exceptions/ExceptionMapper.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/exceptions/ExceptionMapper.java
@@ -67,7 +67,9 @@ import java.sql.SQLTransactionRollbackException;
 import java.sql.SQLTransientException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
-import java.util.stream.IntStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.mariadb.jdbc.MariaDbConnection;
 import org.mariadb.jdbc.MariaDbStatement;
@@ -76,7 +78,7 @@ import org.mariadb.jdbc.internal.util.SqlStates;
 
 public class ExceptionMapper {
 
-  private static final int[] LOCK_DEADLOCK_ERROR_CODES = new int[]{1205, 1213, 1614};
+  private static final Set<Integer> LOCK_DEADLOCK_ERROR_CODES = new HashSet<>(Arrays.asList(1205, 1213, 1614));
 
   /**
    * Helper to throw exception.
@@ -136,7 +138,7 @@ public class ExceptionMapper {
     if (exception.getSQLState() != null) {
       if (connection != null
           && exception.getSQLState() != null
-          && (IntStream.of(LOCK_DEADLOCK_ERROR_CODES).anyMatch(lockCode -> lockCode == exception.getErrorCode()))) {
+          && LOCK_DEADLOCK_ERROR_CODES.contains(exception.getErrorCode())) {
 
         if (connection.includeDeadLockInfo()) {
           try {

--- a/src/main/java/org/mariadb/jdbc/internal/util/exceptions/ExceptionMapper.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/exceptions/ExceptionMapper.java
@@ -67,12 +67,16 @@ import java.sql.SQLTransactionRollbackException;
 import java.sql.SQLTransientException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.util.stream.IntStream;
+
 import org.mariadb.jdbc.MariaDbConnection;
 import org.mariadb.jdbc.MariaDbStatement;
 import org.mariadb.jdbc.internal.util.SqlStates;
 
 
 public class ExceptionMapper {
+
+  private static final int[] LOCK_DEADLOCK_ERROR_CODES = new int[]{1205, 1213, 1614};
 
   /**
    * Helper to throw exception.
@@ -132,7 +136,7 @@ public class ExceptionMapper {
     if (exception.getSQLState() != null) {
       if (connection != null
           && exception.getSQLState() != null
-          && (1205 == exception.getErrorCode() || 1614 == exception.getErrorCode())) {
+          && (IntStream.of(LOCK_DEADLOCK_ERROR_CODES).anyMatch(lockCode -> lockCode == exception.getErrorCode()))) {
 
         if (connection.includeDeadLockInfo()) {
           try {


### PR DESCRIPTION
- 1213 ER_LOCK_DEADLOCK was not considered to run 'SHOW ENGINE INNODB STATUS'. In this case, lock/deadlock information is also required when corresponding option is enabled from a client-side (includeInnodbStatusInDeadlockExceptions=true)