### PR TITLE
[OSGi] Support the Data Service Specification for JDBC™ Technology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ For significant feature additions, we like to have an open issue in [MariaDB JIR
 
 These are the set of tools which are required in order to complete any build.  Follow the links to download and install them on your own before continuing.
 
+* At least one GPG Key see https://help.github.com/en/articles/generating-a-new-gpg-key
 * [Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) ( with [JCE policies](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html) if using TLS/SSL)
 * IDE (eclipse / netbean / intelliJ) with maven and GIT plugins
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <version.file>src/main/java/org/mariadb/jdbc/internal/util/constant/Version.java</version.file>
         <checkstyleVersion>8.12</checkstyleVersion>
         <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
+        <osgi.version>4.3.1</osgi.version>
         <driver.version.major>2</driver.version.major>
         <driver.version.minor>4</driver.version.minor>
         <driver.version.patch>0</driver.version.patch>
@@ -294,9 +295,8 @@
                             <Bundle-SymbolicName>org.mariadb.jdbc</Bundle-SymbolicName>
                             <Automatic-Module-Name>org.mariadb.jdbc</Automatic-Module-Name>
                             <Export-Package>org.mariadb.jdbc</Export-Package>
-                            <Import-Package>
-                                javax.naming,javax.management,javax.net;resolution:=optional,javax.net.ssl;resolution:=optional,javax.sql,javax.transaction.xa;resolution:=optional,org.slf4j;resolution:=optional
-                            </Import-Package>
+                            <Import-Package>org.osgi.framework,javax.naming,javax.management,javax.net;resolution:=optional,javax.net.ssl;resolution:=optional,javax.sql,org.osgi.service.jdbc;resolution:=optional,javax.transaction.xa;resolution:=optional,org.slf4j;resolution:=optional</Import-Package>
+                            <Bundle-Activator>org.mariadb.jdbc.internal.osgi.MariaDbActivator</Bundle-Activator>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -409,5 +409,19 @@
             <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
+        
+        <!-- dependecies provided by an OSGi-Framework -->
+		<dependency>
+		    <groupId>org.osgi</groupId>
+		    <artifactId>org.osgi.core</artifactId>
+		    <version>${osgi.version}</version>
+		    <scope>provided</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.osgi</groupId>
+		    <artifactId>org.osgi.compendium</artifactId>
+		    <version>${osgi.version}</version>
+		    <scope>provided</scope>
+		</dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/mariadb/jdbc/internal/osgi/MariaDbActivator.java
+++ b/src/main/java/org/mariadb/jdbc/internal/osgi/MariaDbActivator.java
@@ -55,6 +55,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 
 import org.mariadb.jdbc.Driver;
+import org.mariadb.jdbc.MariaDbDatabaseMetaData;
 import org.mariadb.jdbc.internal.util.constant.Version;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -73,8 +74,8 @@ public class MariaDbActivator implements BundleActivator {
   public void start(BundleContext context) throws Exception {
     Dictionary<String, Object> properties = new Hashtable<>();
     properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_CLASS, Driver.class.getName());
-    properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_NAME, "JDBC driver for MariaDB and MySQL");
-    properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_VERSION, Version.majorVersion + "." + Version.minorVersion);
+    properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_NAME, MariaDbDatabaseMetaData.DRIVER_NAME);
+    properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_VERSION, Version.version);
     service = context.registerService(DataSourceFactory.class, new MariaDbDataSourceFactory(), properties);
   }
 

--- a/src/main/java/org/mariadb/jdbc/internal/osgi/MariaDbActivator.java
+++ b/src/main/java/org/mariadb/jdbc/internal/osgi/MariaDbActivator.java
@@ -1,0 +1,86 @@
+/*
+ *
+ * MariaDB Client for Java
+ *
+ * Copyright (c) 2019 Christoph Läubrich
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to Monty Program Ab info@montyprogram.com.
+ *
+ * This particular MariaDB Client for Java file is work
+ * derived from a Drizzle-JDBC. Drizzle-JDBC file which is covered by subject to
+ * the following copyright and notice provisions:
+ *
+ * Copyright (c) 2009-2011, Marcus Eriksson
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of the driver nor the names of its contributors may not be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS  AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package org.mariadb.jdbc.internal.osgi;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.mariadb.jdbc.Driver;
+import org.mariadb.jdbc.internal.util.constant.Version;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.jdbc.DataSourceFactory;
+
+/**
+ * The MariaDbActivator registers the JDBC Service with the OSGi-Framework.
+ * 
+ */
+public class MariaDbActivator implements BundleActivator {
+
+  private ServiceRegistration<DataSourceFactory> service;
+
+  @Override
+  public void start(BundleContext context) throws Exception {
+    Dictionary<String, Object> properties = new Hashtable<>();
+    properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_CLASS, Driver.class.getName());
+    properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_NAME, "JDBC driver for MariaDB and MySQL");
+    properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_VERSION, Version.majorVersion + "." + Version.minorVersion);
+    service = context.registerService(DataSourceFactory.class, new MariaDbDataSourceFactory(), properties);
+  }
+
+  @Override
+  public void stop(BundleContext context) throws Exception {
+    service.unregister();
+  }
+
+}

--- a/src/main/java/org/mariadb/jdbc/internal/osgi/MariaDbDataSourceFactory.java
+++ b/src/main/java/org/mariadb/jdbc/internal/osgi/MariaDbDataSourceFactory.java
@@ -1,0 +1,134 @@
+/*
+ *
+ * MariaDB Client for Java
+ *
+ * Copyright (c) 2019 Christoph Läubrich
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to Monty Program Ab info@montyprogram.com.
+ *
+ * This particular MariaDB Client for Java file is work
+ * derived from a Drizzle-JDBC. Drizzle-JDBC file which is covered by subject to
+ * the following copyright and notice provisions:
+ *
+ * Copyright (c) 2009-2011, Marcus Eriksson
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of the driver nor the names of its contributors may not be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS  AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package org.mariadb.jdbc.internal.osgi;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.XADataSource;
+
+import org.mariadb.jdbc.Driver;
+import org.mariadb.jdbc.MariaDbDataSource;
+import org.osgi.service.jdbc.DataSourceFactory;
+
+public class MariaDbDataSourceFactory implements DataSourceFactory {
+
+  @Override
+  public MariaDbDataSource createDataSource(Properties props) throws SQLException {
+    MariaDbDataSource source = new MariaDbDataSource();
+    if (props != null) {
+      if (props.containsKey(JDBC_DATABASE_NAME)) {
+        source.setDatabaseName(props.getProperty(JDBC_DATABASE_NAME));
+      }
+      if (props.containsKey(JDBC_DATASOURCE_NAME)) {
+        // not supported?
+      }
+      if (props.containsKey(JDBC_DESCRIPTION)) {
+        // not supported?
+      }
+      if (props.containsKey(JDBC_NETWORK_PROTOCOL)) {
+        // not supported?
+      }
+      if (props.containsKey(JDBC_PASSWORD)) {
+        source.setPassword(props.getProperty(JDBC_PASSWORD));
+      }
+      if (props.containsKey(JDBC_PORT_NUMBER)) {
+        source.setPortNumber(Integer.parseInt(props.getProperty(JDBC_PORT_NUMBER)));
+      }
+      if (props.containsKey(JDBC_ROLE_NAME)) {
+        // not supported?
+      }
+      if (props.containsKey(JDBC_SERVER_NAME)) {
+        source.setServerName(props.getProperty(JDBC_SERVER_NAME));
+      }
+      if (props.containsKey(JDBC_URL)) {
+        source.setUrl(props.getProperty(JDBC_URL));
+      }
+      if (props.containsKey(JDBC_USER)) {
+        source.setUser(props.getProperty(JDBC_USER));
+      }
+      if (props.containsKey(JDBC_INITIAL_POOL_SIZE)) {
+        // not supported?
+      }
+      if (props.containsKey(JDBC_MAX_IDLE_TIME)) {
+        // not supported?
+      }
+      if (props.containsKey(JDBC_MAX_STATEMENTS)) {
+        // not supported?
+      }
+      if (props.containsKey(JDBC_MAX_POOL_SIZE)) {
+        // not supported?
+      }
+      if (props.containsKey(JDBC_MIN_POOL_SIZE)) {
+        // not supported?
+      }
+    }
+    return source;
+  }
+
+  @Override
+  public ConnectionPoolDataSource createConnectionPoolDataSource(Properties props) throws SQLException {
+    return createDataSource(props);
+  }
+
+  @Override
+  public XADataSource createXADataSource(Properties props) throws SQLException {
+    return createDataSource(props);
+  }
+
+  @Override
+  public Driver createDriver(Properties props) throws SQLException {
+    return new Driver();
+  }
+
+}


### PR DESCRIPTION
Currently users are enforced to write their own code or using third party wrappers to use MariaDB together with OSGi JDBC/JPA Service,

This PR adds support for the [OSGi Data Service Specification for JDBC™ Technology](https://osgi.org/specification/osgi.cmpn/7.0.0/service.jdbc.html)
This allows users of OSGi to use the MariaDB driver in a generic fashion. This is also a perquisite for using MariaDB together with the OSGi JPA Specification.

Since this part of the code is only activated inside an OSGi-Framework for all other users this change is completely transparent.