### PR TITLE
Remove the check of innodb_log_file_size condition when decide checkMaxAllowedPacketMoreXXm in BaseTest.Java

### DIFF
--- a/src/test/java/org/mariadb/jdbc/BaseTest.java
+++ b/src/test/java/org/mariadb/jdbc/BaseTest.java
@@ -681,21 +681,13 @@ public class BaseTest {
     assertTrue(rs.next());
     long maxAllowedPacket = rs.getLong(1);
 
-    rs = st.executeQuery("select @@innodb_log_file_size");
-    assertTrue(rs.next());
-    long innodbLogFileSize = rs.getLong(1);
-
     if (maxAllowedPacket < 8 * 1024 * 1024L) {
 
       System.out.println(
           "test '" + testName + "' skipped  due to server variable max_allowed_packet < 8M");
       return false;
     }
-    if (innodbLogFileSize < 80 * 1024 * 1024L) {
-      System.out.println(
-          "test '" + testName + "' skipped  due to server variable innodb_log_file_size < 80M");
-      return false;
-    }
+
     return true;
   }
 
@@ -725,10 +717,6 @@ public class BaseTest {
     assertTrue(rs.next());
     long maxAllowedPacket = rs.getLong(1);
 
-    rs = st.executeQuery("select @@innodb_log_file_size");
-    assertTrue(rs.next());
-    long innodbLogFileSize = rs.getLong(1);
-
     if (maxAllowedPacket < 20 * 1024 * 1024L) {
 
       if (displayMessage) {
@@ -737,13 +725,7 @@ public class BaseTest {
       }
       return false;
     }
-    if (innodbLogFileSize < 200 * 1024 * 1024L) {
-      if (displayMessage) {
-        System.out.println(
-            "test '" + testName + "' skipped  due to server variable innodb_log_file_size < 200M");
-      }
-      return false;
-    }
+
     return true;
   }
 
@@ -773,21 +755,10 @@ public class BaseTest {
     assertTrue(rs.next());
     long maxAllowedPacket = rs.getLong(1);
 
-    rs = st.executeQuery("select @@innodb_log_file_size");
-    assertTrue(rs.next());
-    long innodbLogFileSize = rs.getLong(1);
-
     if (maxAllowedPacket < 40 * 1024 * 1024L) {
       if (displayMsg) {
         System.out.println(
             "test '" + testName + "' skipped  due to server variable max_allowed_packet < 40M");
-      }
-      return false;
-    }
-    if (innodbLogFileSize < 400 * 1024 * 1024L) {
-      if (displayMsg) {
-        System.out.println(
-            "test '" + testName + "' skipped  due to server variable innodb_log_file_size < 400M");
       }
       return false;
     }


### PR DESCRIPTION

Hi,

In MariaDB Connector J tests, there is a condition to check whether the max_allowed_packet is greater than certain value, and the previous logic is as follows:
max_allowed_packet > value && innodb_log_file_size > 10*value.

Then for actual test, when max_allowed_packet > value and innodb_log_file_size < 10*value on server, it will regard it as max_allowed_packet < value, and certain test will fail, e.g. send40mSqlCompressDataException.

I think this is unreasonable for test itself, and the condition to check innodb_log_file_size should be removed.

Can you help review the change for it and give your comment and approval?

Thanks & Best Regards,
Qianqian Bu