### PR TITLE
runLongTest system property does not work as expected

### DIFF
--- a/src/test/java/org/mariadb/jdbc/BaseTest.java
+++ b/src/test/java/org/mariadb/jdbc/BaseTest.java
@@ -181,7 +181,7 @@ public class BaseTest {
   @BeforeClass()
   public static void beforeClassBaseTest() throws SQLException {
     String url = System.getProperty("dbUrl", mDefUrl);
-    runLongTest = Boolean.getBoolean(System.getProperty("runLongTest", "false"));
+    runLongTest = Boolean.parseBoolean(System.getProperty("runLongTest", "false"));
     testSingleHost = Boolean.parseBoolean(System.getProperty("testSingleHost", "true"));
 
     if (testSingleHost) {


### PR DESCRIPTION
In the test suite, there is a system property runLongTest, it used the wrong method Boolean.getBoolean to parse it which resulted the value of runLongTest was always false. Should use Boolean.parseBoolean instead.