### PR TITLE
Should clear AbstractQueryProtocol::localInfileInputStream field after set MariaDbStatement.setLocalInfileInputStream if throw exception

### DIFF
--- a/src/test/java/org/mariadb/jdbc/StatementTest.java
+++ b/src/test/java/org/mariadb/jdbc/StatementTest.java
@@ -309,6 +309,7 @@ public class StatementTest extends BaseTest {
           fail();
         }
         assertEquals(ER_LOAD_DATA_INVALID_COLUMN_STATE, sqlException.getSQLState());
+        mysqlStatement.setLocalInfileInputStream(null); //otherwise, localInfileInputStream will not be null, which cause false logic in readLocalInfilePacket and test like LocalInfileInputStreamTest#testLocalInfileUnValidInterceptor will fail if run after it
       }
     } finally {
       try {


### PR DESCRIPTION
There are three tests:
StatementTest#testLoadDataInvalidColumn and 
LocalInfileInputStreamTest#testLocalInfileUnValidInterceptor

if the first test is ran before the second test cases, the second test case will fail for sure. 

The reason is that 
StatementTest#testLoadDataInvalidColumn  will set AbstractQueryProtocol::localInfileInputStream field but never clear it.
LocalInfileInputStreamTest#testLocalInfileUnValidInterceptor will use AbstractQueryProtocol::readLocalInfilePacket  in which its logic depends on whether AbstractQueryProtocol::localInfileInputStream is null or not to do following work and decide what to write to table.  Since AbstractQueryProtocol::localInfileInputStream is not cleaned in previous test StatementTest#testLoadDataInvalidColumn, it will use the value and try to write this to target table, if the target table columns are suitable the write will be success, and you will find irrelevant data written to test table.
