### PR TITLE
[CONJ-712] RewriteBatchedStatements and useAffectedRows should report no changes correctly

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationBatch.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationBatch.java
@@ -162,7 +162,7 @@ public class CmdInformationBatch implements CmdInformation {
   public long[] getLargeUpdateCounts() {
     if (rewritten) {
       long[] ret = new long[expectedSize];
-      int resultValue;
+      long resultValue;
       if (hasException) {
         resultValue = Statement.EXECUTE_FAILED;
       } else if (updateCounts.size() == 1 && updateCounts.element() == 0) {

--- a/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationBatch.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationBatch.java
@@ -119,7 +119,7 @@ public class CmdInformationBatch implements CmdInformation {
   public int[] getUpdateCounts() {
     if (rewritten) {
       int[] ret = new int[expectedSize];
-      Arrays.fill(ret, hasException ? Statement.EXECUTE_FAILED : Statement.SUCCESS_NO_INFO);
+      Arrays.fill(ret, hasException ? Statement.EXECUTE_FAILED : (updateCounts[0] == 0 ? 0 : Statement.SUCCESS_NO_INFO));
       return ret;
     }
 
@@ -154,7 +154,7 @@ public class CmdInformationBatch implements CmdInformation {
   public long[] getLargeUpdateCounts() {
     if (rewritten) {
       long[] ret = new long[expectedSize];
-      Arrays.fill(ret, hasException ? Statement.EXECUTE_FAILED : Statement.SUCCESS_NO_INFO);
+      Arrays.fill(ret, hasException ? Statement.EXECUTE_FAILED : (updateCounts[0] == 0 ? 0 : Statement.SUCCESS_NO_INFO));
       return ret;
     }
 

--- a/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationBatch.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationBatch.java
@@ -170,6 +170,7 @@ public class CmdInformationBatch implements CmdInformation {
       } else {
         resultValue = Statement.SUCCESS_NO_INFO;
       }
+      Arrays.fill(ret, resultValue);
       return ret;
     }
 

--- a/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationBatch.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationBatch.java
@@ -119,7 +119,15 @@ public class CmdInformationBatch implements CmdInformation {
   public int[] getUpdateCounts() {
     if (rewritten) {
       int[] ret = new int[expectedSize];
-      Arrays.fill(ret, hasException ? Statement.EXECUTE_FAILED : (updateCounts[0] == 0 ? 0 : Statement.SUCCESS_NO_INFO));
+      int resultValue;
+      if (hasException) {
+        resultValue = Statement.EXECUTE_FAILED;
+      } else if (updateCounts.size() == 1 && updateCounts.element() == 0) {
+        resultValue = 0;
+      } else {
+        resultValue = Statement.SUCCESS_NO_INFO;
+      }
+      Arrays.fill(ret, resultValue);
       return ret;
     }
 
@@ -154,7 +162,14 @@ public class CmdInformationBatch implements CmdInformation {
   public long[] getLargeUpdateCounts() {
     if (rewritten) {
       long[] ret = new long[expectedSize];
-      Arrays.fill(ret, hasException ? Statement.EXECUTE_FAILED : (updateCounts[0] == 0 ? 0 : Statement.SUCCESS_NO_INFO));
+      int resultValue;
+      if (hasException) {
+        resultValue = Statement.EXECUTE_FAILED;
+      } else if (updateCounts.size() == 1 && updateCounts.element() == 0) {
+        resultValue = 0;
+      } else {
+        resultValue = Statement.SUCCESS_NO_INFO;
+      }
       return ret;
     }
 


### PR DESCRIPTION
Improvement of https://jira.mariadb.org/browse/CONJ-384

If update of rewritten batch return "no changes" batch return array of "no changes". Otherwise it works as before.

- tested it with our project.  
- test "updateCounts.size() == 1" may be unnecessary