### PR TITLE
Fix: replace [--] with [-] in LOAD LOCAL INFILE regex patterns

### DIFF
--- a/src/main/java/org/mariadb/jdbc/message/ClientMessage.java
+++ b/src/main/java/org/mariadb/jdbc/message/ClientMessage.java
@@ -35,7 +35,7 @@ public interface ClientMessage {
   /** Precompiled pattern for LOAD DATA LOCAL INFILE with parameter placeholder */
   Pattern LOAD_LOCAL_PATTERN_PARAM =
       Pattern.compile(
-          "^((\\s[--]|#).*(\\r"
+          "^((\\s[-]|#).*(\\r"
               + "\\n"
               + "|\\r"
               + "|\\n"
@@ -56,7 +56,7 @@ public interface ClientMessage {
     // Check for direct filename match in SQL
     String escapedFileName = Pattern.quote(fileName.replace("\\", "\\\\"));
     String reg =
-        "^((\\s[--]|#).*(\\r"
+        "^((\\s[-]|#).*(\\r"
             + "\\n"
             + "|\\r"
             + "|\\n"


### PR DESCRIPTION
[--] is a degenerate character range (start == end) that is not portable across regex engines. [-] unambiguously matches a literal hyphen and is the correct way to express a single-character class containing only -.