### PR TITLE
use Locale.ROOT in DurationCodec text formatting

### DIFF
--- a/src/main/java/org/mariadb/jdbc/plugin/codec/DurationCodec.java
+++ b/src/main/java/org/mariadb/jdbc/plugin/codec/DurationCodec.java
@@ -10,6 +10,7 @@ import java.sql.SQLDataException;
 import java.time.Duration;
 import java.util.Calendar;
 import java.util.EnumSet;
+import java.util.Locale;
 import org.mariadb.jdbc.client.*;
 import org.mariadb.jdbc.client.socket.Writer;
 import org.mariadb.jdbc.client.util.MutableInt;
@@ -208,9 +209,11 @@ public class DurationCodec implements Codec<Duration> {
     encoder.writeByte('\'');
     if (microSecond != 0) {
       encoder.writeAscii(
-          String.format("%d:%02d:%02d.%06d", s / 3600, (s % 3600) / 60, (s % 60), microSecond));
+          String.format(
+              Locale.ROOT, "%d:%02d:%02d.%06d", s / 3600, (s % 3600) / 60, (s % 60), microSecond));
     } else {
-      encoder.writeAscii(String.format("%d:%02d:%02d", s / 3600, (s % 3600) / 60, (s % 60)));
+      encoder.writeAscii(
+          String.format(Locale.ROOT, "%d:%02d:%02d", s / 3600, (s % 3600) / 60, (s % 60)));
     }
     encoder.writeByte('\'');
   }


### PR DESCRIPTION
A Duration bound on a text-protocol statement is formatted with String.format under the default locale, so on hosts whose locale uses non-Latin digits (ar/fa/bn) the TIME literal comes out as non-ASCII numerals that writeAscii then truncates to garbage. Format with Locale.ROOT, matching the locale-independent encoding the other codecs already use.