### PR TITLE
call inflater.end() in finally in CompressInputStream

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/socket/impl/CompressInputStream.java
+++ b/src/main/java/org/mariadb/jdbc/client/socket/impl/CompressInputStream.java
@@ -164,8 +164,9 @@ public class CompressInputStream extends InputStream {
         }
       } catch (DataFormatException dfe) {
         throw new IOException(dfe);
+      } finally {
+        inflater.end();
       }
-      inflater.end();
       end = packetLength;
     } else {
       buf = intermediaryBuf;


### PR DESCRIPTION
retrieveBuffer creates a new Inflater but only calls end() on the success path, so a server sending a malformed compressed packet leaks the native zlib stream once inflate throws DataFormatException, and the length-mismatch IOException branch leaks the same way. Move end() into a finally so it runs on every path, matching the success-path call already there.