### PR TITLE
use Locale.ROOT in date/time codec text formatting

### DIFF
--- a/src/main/java/org/mariadb/jdbc/plugin/codec/DateCodec.java
+++ b/src/main/java/org/mariadb/jdbc/plugin/codec/DateCodec.java
@@ -9,6 +9,7 @@ import java.sql.SQLDataException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.EnumSet;
+import java.util.Locale;
 import org.mariadb.jdbc.client.*;
 import org.mariadb.jdbc.client.socket.Writer;
 import org.mariadb.jdbc.client.util.MutableInt;
@@ -76,7 +77,7 @@ public class DateCodec implements Codec<Date> {
       Writer encoder, Context context, Date val, Calendar providedCal, Long maxLen)
       throws IOException {
     Calendar cal = providedCal == null ? context.getDefaultCalendar() : providedCal;
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
     sdf.setTimeZone(cal.getTimeZone());
     String dateString = sdf.format(val);
 

--- a/src/main/java/org/mariadb/jdbc/plugin/codec/TimeCodec.java
+++ b/src/main/java/org/mariadb/jdbc/plugin/codec/TimeCodec.java
@@ -10,6 +10,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.EnumSet;
+import java.util.Locale;
 import org.mariadb.jdbc.client.ColumnDecoder;
 import org.mariadb.jdbc.client.Context;
 import org.mariadb.jdbc.client.DataType;
@@ -83,7 +84,7 @@ public class TimeCodec implements Codec<Time> {
       Writer encoder, Context context, Time val, Calendar providedCal, Long maxLen)
       throws IOException {
     Calendar cal = providedCal == null ? Calendar.getInstance() : providedCal;
-    SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS");
+    SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS", Locale.ROOT);
     sdf.setTimeZone(cal.getTimeZone());
     String dateString = sdf.format(val);
 

--- a/src/main/java/org/mariadb/jdbc/plugin/codec/UtilDateCodec.java
+++ b/src/main/java/org/mariadb/jdbc/plugin/codec/UtilDateCodec.java
@@ -9,6 +9,7 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.EnumSet;
+import java.util.Locale;
 import org.mariadb.jdbc.client.ColumnDecoder;
 import org.mariadb.jdbc.client.Context;
 import org.mariadb.jdbc.client.DataType;
@@ -105,7 +106,7 @@ public class UtilDateCodec implements Codec<java.util.Date> {
       Writer encoder, Context context, java.util.Date val, Calendar providedCal, Long maxLen)
       throws IOException {
     Calendar cal = providedCal == null ? context.getDefaultCalendar() : providedCal;
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT);
     sdf.setTimeZone(cal.getTimeZone());
     String dateString = sdf.format(val);
 


### PR DESCRIPTION
DateCodec, TimeCodec and UtilDateCodec build the text-protocol literal with new SimpleDateFormat(pattern) under the default locale, so on hosts whose locale uses non-Latin digits (ar/fa/bn) the numeric fields come out as non-ASCII numerals that writeAscii then truncates to garbage. Format with Locale.ROOT, matching the locale-independent encoding the other codecs already use.