### PR TITLE
encode caching_sha2 clear password as UTF-8

### DIFF
--- a/src/main/java/org/mariadb/jdbc/plugin/authentication/standard/CachingSha2PasswordPlugin.java
+++ b/src/main/java/org/mariadb/jdbc/plugin/authentication/standard/CachingSha2PasswordPlugin.java
@@ -222,7 +222,7 @@ public class CachingSha2PasswordPlugin implements AuthenticationPlugin {
                         + " explicitly passed on configuration.",
                     "S1010");
               }
-              byte[] bytePwd = authenticationData.getBytes();
+              byte[] bytePwd = authenticationData.getBytes(StandardCharsets.UTF_8);
               byte[] nullEndedValue = new byte[bytePwd.length + 1];
               System.arraycopy(bytePwd, 0, nullEndedValue, 0, bytePwd.length);
               new AuthMoreRawPacket(nullEndedValue).encode(out, context);


### PR DESCRIPTION
The full-authentication clear-password path in CachingSha2PasswordPlugin.process (line 225) builds the password bytes with authenticationData.getBytes(), using the platform default charset, while the fast-auth scramble at line 59 and every other password in this package use getBytes(UTF_8). On a JVM whose default charset is not UTF-8 a non-ASCII password is sent with the wrong bytes, so caching_sha2 full auth fails where fast auth would have passed.