### PR TITLE
synchronize PrepareCache.reset()

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/impl/PrepareCache.java
+++ b/src/main/java/org/mariadb/jdbc/client/impl/PrepareCache.java
@@ -85,7 +85,7 @@ public final class PrepareCache extends LinkedHashMap<String, CachedPrepareResul
     throw new IllegalStateException("not available method");
   }
 
-  public void reset() {
+  public synchronized void reset() {
     for (CachedPrepareResultPacket prep : values()) {
       prep.reset();
     }


### PR DESCRIPTION
Found this stress-testing the prepare cache during failover. get() and put() are synchronized, but reset() iterates values() and clears the LinkedHashMap with no lock. A reconnect calling resetPrepareCache() while another thread runs put() then races on a non-thread-safe map, giving a ConcurrentModificationException or a corrupted cache. Lock reset() on the same monitor.