### PR TITLE
use Locale.ROOT when lowercasing host address parameters

### DIFF
--- a/src/main/java/org/mariadb/jdbc/HostAddress.java
+++ b/src/main/java/org/mariadb/jdbc/HostAddress.java
@@ -6,6 +6,7 @@ package org.mariadb.jdbc;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import org.mariadb.jdbc.export.HaMode;
 import org.mariadb.jdbc.export.SslMode;
@@ -212,8 +213,8 @@ public class HostAddress {
         throw new IllegalArgumentException(
             "Invalid connection URL, expected key=value pairs, found " + array[i]);
       }
-      String key = token[0].toLowerCase();
-      String value = token[1].toLowerCase();
+      String key = token[0].toLowerCase(Locale.ROOT);
+      String value = token[1].toLowerCase(Locale.ROOT);
 
       switch (key) {
         case "host":


### PR DESCRIPTION
host token in address=(host=..) is lowercased with the default locale, mangling names containing 'I' under tr_TR; pin Locale.ROOT as HostnameVerifier already does.