### PR TITLE
create gssapi jaas config temp file with owner-only permissions

### DIFF
--- a/src/main/java/org/mariadb/jdbc/plugin/authentication/addon/gssapi/StandardGssapiAuthentication.java
+++ b/src/main/java/org/mariadb/jdbc/plugin/authentication/addon/gssapi/StandardGssapiAuthentication.java
@@ -4,6 +4,9 @@
 package org.mariadb.jdbc.plugin.authentication.addon.gssapi;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.PrivilegedExceptionAction;
 import java.sql.SQLException;
 import javax.security.auth.Subject;
@@ -42,7 +45,19 @@ public class StandardGssapiAuthentication implements GssapiAuth {
     if (System.getProperty("java.security.auth.login.config") == null) {
       final File jaasConfFile;
       try {
-        jaasConfFile = File.createTempFile("jaas.conf", null);
+        Path jaasPath;
+        try {
+          jaasPath =
+              Files.createTempFile(
+                  "jaas.conf",
+                  null,
+                  PosixFilePermissions.asFileAttribute(
+                      PosixFilePermissions.fromString("rw-------")));
+        } catch (UnsupportedOperationException e) {
+          // non-POSIX filesystem (e.g. windows) : rely on the per-user temp directory
+          jaasPath = Files.createTempFile("jaas.conf", null);
+        }
+        jaasConfFile = jaasPath.toFile();
         try (PrintStream bos = new PrintStream(new FileOutputStream(jaasConfFile))) {
           bos.print(
               "Krb5ConnectorContext {\n"


### PR DESCRIPTION
The jaas config written in StandardGssapiAuthentication.authenticate is created with File.createTempFile, which leaves it world-readable (rw-r--r-- under the usual umask) in the shared temp dir while its path gets published JVM-wide as java.security.auth.login.config. Switch to Files.createTempFile with rw------- so only the connecting user can read it, falling back to the default on non-POSIX filesystems.