### PR TITLE
use constant-time comparison in validateFingerPrint

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/impl/StandardClient.java
+++ b/src/main/java/org/mariadb/jdbc/client/impl/StandardClient.java
@@ -585,7 +585,9 @@ public class StandardClient implements Client, AutoCloseable {
       final String hashHex = StringUtils.byteArrayToHexString(digest);
       final String serverValidationHex =
           new String(validationHash, 1, validationHash.length - 1, StandardCharsets.US_ASCII);
-      return hashHex.equals(serverValidationHex);
+      return MessageDigest.isEqual(
+          hashHex.getBytes(StandardCharsets.US_ASCII),
+          serverValidationHex.getBytes(StandardCharsets.US_ASCII));
 
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalStateException("SHA-256 MessageDigest expected to be not available", e);


### PR DESCRIPTION
non-constant-time check on the server certificate fingerprint token in validateFingerPrint:
- hashHex is derived from the user's hashed password, the handshake seed and the cert fingerprint, then compared to the server value with String.equals
- String.equals returns on the first differing char, so the time before the connection proceeds or aborts leaks the matching prefix length of a secret-derived token
- a man-in-the-middle fixes the seed and its own fingerprint across reconnects, recovers the token byte by byte and replays it to pass the anti-MitM check without the password
swapped the compare to MessageDigest.isEqual.