### PR TITLE
match local infile filename case-sensitively

### DIFF
--- a/src/main/java/org/mariadb/jdbc/message/ClientMessage.java
+++ b/src/main/java/org/mariadb/jdbc/message/ClientMessage.java
@@ -59,9 +59,9 @@ public interface ClientMessage {
             + "\\n"
             + "|\\r"
             + "|\\n"
-            + ")|\\s*/\\*([^*]|\\*[^/])*\\*/|.)*\\s*LOAD\\s+(DATA|XML)\\s+((LOW_PRIORITY|CONCURRENT)\\s+)?LOCAL\\s+INFILE\\s+'"
+            + ")|\\s*/\\*([^*]|\\*[^/])*\\*/|.)*\\s*LOAD\\s+(DATA|XML)\\s+((LOW_PRIORITY|CONCURRENT)\\s+)?LOCAL\\s+INFILE\\s+'(?-i:"
             + escapedFileName
-            + "'";
+            + ")'";
 
     Pattern pattern = Pattern.compile(reg, Pattern.CASE_INSENSITIVE);
     if (pattern.matcher(sql).find()) {
@@ -73,7 +73,7 @@ public interface ClientMessage {
       if (LOAD_LOCAL_PATTERN_PARAM.matcher(sql).find() && parameters.size() > 0) {
         String paramString = parameters.get(0).bestEffortStringValue(context);
         if (paramString != null) {
-          return paramString.equalsIgnoreCase("'" + fileName.replace("\\", "\\\\") + "'");
+          return paramString.equals("'" + fileName.replace("\\", "\\\\") + "'");
         }
         return true;
       }

--- a/src/test/java/org/mariadb/jdbc/unit/message/ClientMessageTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/message/ClientMessageTest.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (c) 2012-2014 Monty Program Ab
+// Copyright (c) 2015-2025 MariaDB Corporation Ab
+package org.mariadb.jdbc.unit.message;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.message.ClientMessage;
+
+public class ClientMessageTest {
+
+  @Test
+  public void validateLocalFileNameCaseSensitive() {
+    String sql = "LOAD DATA LOCAL INFILE '/tmp/foo.txt' INTO TABLE t";
+
+    // file requested by server matches the query
+    Assertions.assertTrue(ClientMessage.validateLocalFileName(sql, null, "/tmp/foo.txt", null));
+
+    // server asks for a path differing only in case : distinct file on case-sensitive
+    // filesystems, must be refused
+    Assertions.assertFalse(ClientMessage.validateLocalFileName(sql, null, "/tmp/FOO.txt", null));
+    Assertions.assertFalse(ClientMessage.validateLocalFileName(sql, null, "/tmp/foo.TXT", null));
+
+    // statement keywords stay case-insensitive
+    Assertions.assertTrue(
+        ClientMessage.validateLocalFileName(
+            "load data local infile '/tmp/foo.txt'", null, "/tmp/foo.txt", null));
+
+    // unrelated file refused
+    Assertions.assertFalse(ClientMessage.validateLocalFileName(sql, null, "/etc/passwd", null));
+  }
+}


### PR DESCRIPTION
local infile validation matched the server-requested filename case-insensitively, so a rogue or mitm server can answer a legitimate LOAD DATA LOCAL INFILE with a path that only differs in case and have the client read a different file on case-sensitive filesystems:
- direct match compiled the filename into the regex under Pattern.CASE_INSENSITIVE
- parameterized match compared with equalsIgnoreCase
- statement keywords still need case-insensitive matching, the path does not
wrapped the path in (?-i:) and switched the parameter comparison to equals so the keywords stay case-insensitive but the filename matches exactly.
