### PR TITLE
read parsec auth iteration count as unsigned byte

### DIFF
--- a/src/main/java/org/mariadb/jdbc/plugin/authentication/standard/ParsecPasswordPlugin.java
+++ b/src/main/java/org/mariadb/jdbc/plugin/authentication/standard/ParsecPasswordPlugin.java
@@ -67,7 +67,7 @@ public class ParsecPasswordPlugin implements AuthenticationPlugin {
 
     if (buf.readableBytes() > 2) {
       firstByte = buf.readByte();
-      iterations = buf.readByte();
+      iterations = buf.readUnsignedByte();
     }
 
     if (firstByte != 0x50 || iterations > 20) {


### PR DESCRIPTION
**Signed read of the parsec iteration factor**
The PBKDF2 iteration factor in the ext-salt is read with `readByte()`, so a server byte >= 0x80 sign-extends past the `iterations > 20` check and feeds a negative shift into `1024 << iterations`; 0xFF lands on a zero iteration count and `PBEKeySpec` then throws an uncaught `IllegalArgumentException`. Reading it with `readUnsignedByte()` keeps the bound effective across the full 0-255 range.