### PR TITLE
fix unsafe escaping in enquoteLiteral and enquoteNCharLiteral

### DIFF
--- a/src/main/java/org/mariadb/jdbc/Driver.java
+++ b/src/main/java/org/mariadb/jdbc/Driver.java
@@ -13,7 +13,6 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.*;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.mariadb.jdbc.client.Client;
 import org.mariadb.jdbc.client.impl.MultiPrimaryClient;
@@ -30,25 +29,12 @@ public final class Driver implements java.sql.Driver {
   private static final Pattern identifierPattern =
       Pattern.compile("[0-9a-zA-Z$_\\u0080-\\uFFFF]*", Pattern.UNICODE_CASE);
 
-  private static final Pattern escapePattern = Pattern.compile("[\u0000'\"\b\n\r\t\u001A\\\\]");
-
-  private static final Map<String, String> mapper = new HashMap<>();
-
   static {
     try {
       DriverManager.registerDriver(new Driver());
     } catch (SQLException e) {
       // eat
     }
-    mapper.put("\u0000", "\\0");
-    mapper.put("'", "\\\\'");
-    mapper.put("\"", "\\\\\"");
-    mapper.put("\b", "\\\\b");
-    mapper.put("\n", "\\\\n");
-    mapper.put("\r", "\\\\r");
-    mapper.put("\t", "\\\\t");
-    mapper.put("\u001A", "\\\\Z");
-    mapper.put("\\", "\\\\");
   }
 
   /**
@@ -230,15 +216,17 @@ public final class Driver implements java.sql.Driver {
    */
   // @Override when not supporting java 8
   public static String enquoteLiteral(String val) {
-    Matcher matcher = escapePattern.matcher(val);
-    StringBuffer escapedVal = new StringBuffer("'");
-
-    while (matcher.find()) {
-      matcher.appendReplacement(escapedVal, mapper.get(matcher.group()));
-    }
-    matcher.appendTail(escapedVal);
-    escapedVal.append("'");
-    return escapedVal.toString();
+    return "'"
+        + val.replace("\\", "\\\\")
+            .replace("'", "''")
+            .replace("\"", "\\\"")
+            .replace("\u0000", "\\0")
+            .replace("\b", "\\b")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+            .replace("\u001A", "\\Z")
+        + "'";
   }
 
   /**

--- a/src/main/java/org/mariadb/jdbc/Statement.java
+++ b/src/main/java/org/mariadb/jdbc/Statement.java
@@ -1686,6 +1686,6 @@ public class Statement implements java.sql.Statement {
    */
   // @Override when not supporting java 8
   public String enquoteNCharLiteral(String val) {
-    return "N'" + val.replace("'", "''") + "'";
+    return "N'" + val.replace("\\", "\\\\").replace("'", "''") + "'";
   }
 }

--- a/src/test/java/org/mariadb/jdbc/integration/StatementTest.java
+++ b/src/test/java/org/mariadb/jdbc/integration/StatementTest.java
@@ -1316,7 +1316,7 @@ public class StatementTest extends Common {
 
     assertEquals("'good_$one'", stmt.enquoteLiteral("good_$one"));
     assertEquals(
-        "'another\\Z\\'\\\"one\\n \\b test'", stmt.enquoteLiteral("another\u001A'\"one\n \b test"));
+        "'another\\Z''\\\"one\\n \\b test'", stmt.enquoteLiteral("another\u001A'\"one\n \b test"));
   }
 
   @Test

--- a/src/test/java/org/mariadb/jdbc/unit/EnquoteLiteralTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/EnquoteLiteralTest.java
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (c) 2012-2014 Monty Program Ab
+// Copyright (c) 2015-2026 MariaDB Corporation Ab
+package org.mariadb.jdbc.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.Driver;
+
+public class EnquoteLiteralTest {
+
+  @Test
+  public void doublesQuote() {
+    // JDBC spec: a single quote is escaped by doubling it
+    assertEquals("'It''s a test'", Driver.enquoteLiteral("It's a test"));
+    assertEquals("'good_$one'", Driver.enquoteLiteral("good_$one"));
+  }
+
+  @Test
+  public void safeUnderBothSqlModes() {
+    // every quote is doubled, so the literal cannot be closed early
+    // (the backslash form 'x\' OR ...' would break out under NO_BACKSLASH_ESCAPES)
+    assertEquals("'x'' OR ''1''=''1'", Driver.enquoteLiteral("x' OR '1'='1"));
+    // a trailing backslash must be doubled, otherwise it escapes the closing quote
+    // in the default sql_mode
+    assertEquals("'a\\\\'", Driver.enquoteLiteral("a\\"));
+    assertEquals("'\\\\'' OR 1=1 -- '", Driver.enquoteLiteral("\\' OR 1=1 -- "));
+  }
+}


### PR DESCRIPTION
**SQL injection in enquoteLiteral / enquoteNCharLiteral**

enquoteLiteral backslash-escapes the embedded quote and never doubles backslashes (its replacement map is passed to Matcher.appendReplacement, which collapses the doubled backslash back to one), so the literal can be closed early: a trailing backslash escapes the closing quote under the default sql_mode, and the `\'` emitted for a quote is a literal backslash plus a terminating quote when sql_mode=NO_BACKSLASH_ESCAPES. enquoteNCharLiteral doubles the quote but leaves backslashes unescaped, breaking out the same way under the default mode, so both now double the backslash and the quote, which is safe under both sql modes and is the doubling the JDBC contract specifies.
