### PR TITLE
mask password in redirect url before logging

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/impl/StandardClient.java
+++ b/src/main/java/org/mariadb/jdbc/client/impl/StandardClient.java
@@ -627,7 +627,7 @@ public class StandardClient implements Client, AutoCloseable {
         if (!matcher.matches()) {
           logger.error(
               "error parsing redirection string '"
-                  + redirectUrl
+                  + hidePassword(redirectUrl)
                   + "'. format must be"
                   + " 'mariadb/mysql://[<user>[:<password>]@]<host>[:<port>]/[<db>[?<opt1>=<value1>[&<opt2>=<value2>]]]'");
           return;
@@ -664,7 +664,8 @@ public class StandardClient implements Client, AutoCloseable {
 
             // properly close current connection
             this.close();
-            logger.info("redirecting connection " + hostAddress + " to " + redirectUrl);
+            logger.info(
+                "redirecting connection " + hostAddress + " to " + hidePassword(redirectUrl));
             // affect redirection to current client
             this.closed = false;
             this.socket = redirectClient.socket;
@@ -675,7 +676,7 @@ public class StandardClient implements Client, AutoCloseable {
             this.reader = redirectClient.reader;
 
           } catch (SQLException e) {
-            logger.error("fail to redirect to '" + redirectUrl + "'");
+            logger.error("fail to redirect to '" + hidePassword(redirectUrl) + "'");
           }
         } catch (UnsupportedEncodingException ee) {
           // eat, still supporting java 8
@@ -686,6 +687,18 @@ public class StandardClient implements Client, AutoCloseable {
     } else {
       this.context.setRedirectUrl(null);
     }
+  }
+
+  /**
+   * Mask the password of a redirection url (scheme://user:password@host...) so the credentials a
+   * server embeds in {@code redirect_url} are not written to the logs.
+   *
+   * @param redirectUrl redirection url
+   * @return url with the password component replaced by {@code ***}
+   */
+  public static String hidePassword(String redirectUrl) {
+    if (redirectUrl == null) return null;
+    return redirectUrl.replaceFirst("(://[^/@:]*:)[^/@]*(@)", "$1***$2");
   }
 
   private void assignStream(OutputStream out, InputStream in, Configuration conf, Long threadId) {

--- a/src/test/java/org/mariadb/jdbc/unit/client/RedirectUrlPasswordMaskTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/client/RedirectUrlPasswordMaskTest.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (c) 2012-2014 Monty Program Ab
+// Copyright (c) 2015-2026 MariaDB Corporation Ab
+package org.mariadb.jdbc.unit.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.client.impl.StandardClient;
+
+class RedirectUrlPasswordMaskTest {
+
+  @Test
+  void maskPasswordInRedirectUrl() {
+    String masked = StandardClient.hidePassword("mariadb://bob:s3cr3t@db2:3307/app?foo=bar");
+    assertEquals("mariadb://bob:***@db2:3307/app?foo=bar", masked);
+    assertFalse(masked.contains("s3cr3t"));
+
+    // password containing ':' must still be fully masked
+    assertEquals(
+        "mysql://bob:***@db2/app", StandardClient.hidePassword("mysql://bob:pa:ss@db2/app"));
+  }
+
+  @Test
+  void leaveUrlWithoutPasswordUntouched() {
+    assertEquals("mariadb://db2:3307/app", StandardClient.hidePassword("mariadb://db2:3307/app"));
+    assertEquals("mariadb://bob@db2/app", StandardClient.hidePassword("mariadb://bob@db2/app"));
+    assertNull(StandardClient.hidePassword(null));
+  }
+}


### PR DESCRIPTION
redirect() parses user:password from a server-sent redirect_url and uses them as connection credentials, but logs the raw url:
- logger.info on a successful redirect prints the full url including the password
- logger.error on parse failure and on redirect failure do the same
- a redirect_url like mariadb://user:pwd@host/db therefore writes the cleartext password to the logs
Masked the password with *** at the three log sites.