### PR TITLE
ignore certificate CN when subjectAltName is present

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/tls/HostnameVerifier.java
+++ b/src/main/java/org/mariadb/jdbc/client/tls/HostnameVerifier.java
@@ -279,26 +279,22 @@ public class HostnameVerifier {
       }
 
       // ***********************************************************
-      // RFC 2818 : legacy fallback using CN (recommendation is using alt-names)
+      // RFC 2818 / RFC 6125 : the Common Name is only a legacy fallback and must be
+      // ignored once the certificate carries subjectAltName entries. Reaching here with
+      // a non-empty SAN set means none of them matched, so the host is not authorized.
       // ***********************************************************
+      if (!subjectAltNames.isEmpty()) {
+        throw new SSLException(
+            normalizedHostMsg(lowerCaseHost) + " doesn't correspond to " + subjectAltNames);
+      }
+
       X500Principal subjectPrincipal = cert.getSubjectX500Principal();
       String cn = extractCommonName(subjectPrincipal.getName(X500Principal.RFC2253));
-
       if (cn == null) {
-        if (subjectAltNames.isEmpty()) {
-          throw new SSLException(
-              "CN not found in certificate principal \""
-                  + subjectPrincipal
-                  + "\" and certificate doesn't contain SAN");
-        } else {
-          throw new SSLException(
-              "CN not found in certificate principal \""
-                  + subjectPrincipal
-                  + "\" and "
-                  + normalizedHostMsg(lowerCaseHost)
-                  + " doesn't correspond to "
-                  + subjectAltNames);
-        }
+        throw new SSLException(
+            "CN not found in certificate principal \""
+                + subjectPrincipal
+                + "\" and certificate doesn't contain SAN");
       }
 
       String normalizedCn = cn.toLowerCase(Locale.ROOT);
@@ -310,15 +306,11 @@ public class HostnameVerifier {
             lowerCaseHost);
       }
       if (!matchDns(lowerCaseHost, normalizedCn)) {
-        String errorMsg =
+        throw new SSLException(
             normalizedHostMsg(lowerCaseHost)
                 + " doesn't correspond to certificate CN \""
                 + normalizedCn
-                + "\"";
-        if (!subjectAltNames.isEmpty()) {
-          errorMsg += " and " + subjectAltNames;
-        }
-        throw new SSLException(errorMsg);
+                + "\"");
       }
 
     } catch (CertificateParsingException cpe) {

--- a/src/main/java/org/mariadb/jdbc/client/tls/HostnameVerifier.java
+++ b/src/main/java/org/mariadb/jdbc/client/tls/HostnameVerifier.java
@@ -279,11 +279,15 @@ public class HostnameVerifier {
       }
 
       // ***********************************************************
-      // RFC 2818 / RFC 6125 : the Common Name is only a legacy fallback and must be
-      // ignored once the certificate carries subjectAltName entries. Reaching here with
-      // a non-empty SAN set means none of them matched, so the host is not authorized.
+      // RFC 6125 §6.4.4 : the Common Name is only a legacy fallback, consulted when the
+      // certificate carries no subjectAltName entry of the type matching the host
+      // (iPAddress for IP hosts, dNSName otherwise), matching the default behavior of
+      // OpenSSL/LibreSSL/BoringSSL. Reaching here with a matching-type SAN present means
+      // none of them matched, so the host is not authorized.
       // ***********************************************************
-      if (!subjectAltNames.isEmpty()) {
+      Extension hostType =
+          (isIPv4(lowerCaseHost) || isIPv6(lowerCaseHost)) ? Extension.IP : Extension.DNS;
+      if (subjectAltNames.hasType(hostType)) {
         throw new SSLException(
             normalizedHostMsg(lowerCaseHost) + " doesn't correspond to " + subjectAltNames);
       }
@@ -291,10 +295,20 @@ public class HostnameVerifier {
       X500Principal subjectPrincipal = cert.getSubjectX500Principal();
       String cn = extractCommonName(subjectPrincipal.getName(X500Principal.RFC2253));
       if (cn == null) {
-        throw new SSLException(
-            "CN not found in certificate principal \""
-                + subjectPrincipal
-                + "\" and certificate doesn't contain SAN");
+        if (subjectAltNames.isEmpty()) {
+          throw new SSLException(
+              "CN not found in certificate principal \""
+                  + subjectPrincipal
+                  + "\" and certificate doesn't contain SAN");
+        } else {
+          throw new SSLException(
+              "CN not found in certificate principal \""
+                  + subjectPrincipal
+                  + "\" and "
+                  + normalizedHostMsg(lowerCaseHost)
+                  + " doesn't correspond to "
+                  + subjectAltNames);
+        }
       }
 
       String normalizedCn = cn.toLowerCase(Locale.ROOT);
@@ -306,11 +320,15 @@ public class HostnameVerifier {
             lowerCaseHost);
       }
       if (!matchDns(lowerCaseHost, normalizedCn)) {
-        throw new SSLException(
+        String errorMsg =
             normalizedHostMsg(lowerCaseHost)
                 + " doesn't correspond to certificate CN \""
                 + normalizedCn
-                + "\"");
+                + "\"";
+        if (!subjectAltNames.isEmpty()) {
+          errorMsg += " and " + subjectAltNames;
+        }
+        throw new SSLException(errorMsg);
       }
 
     } catch (CertificateParsingException cpe) {
@@ -369,6 +387,15 @@ public class HostnameVerifier {
 
     public boolean isEmpty() {
       return generalNames.isEmpty();
+    }
+
+    public boolean hasType(Extension extension) {
+      for (GeneralName generalName : generalNames) {
+        if (generalName.extension == extension) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 }

--- a/src/test/java/org/mariadb/jdbc/unit/client/HostnameVerifierTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/client/HostnameVerifierTest.java
@@ -176,20 +176,25 @@ public class HostnameVerifierTest {
     verifyExceptionEqual(
         "mariadb.org",
         cert,
-        "DNS host \"mariadb.org\" doesn't correspond to certificate "
-            + "CN \"*.mariadb.org\" and SAN[{DNS:\"other.org\"},{DNS:\"www.other.org\"}]");
-    HostnameVerifier.verify("a.mariadb.org", cert, -1);
+        "DNS host \"mariadb.org\" doesn't correspond to "
+            + "SAN[{DNS:\"other.org\"},{DNS:\"www.other.org\"}]");
+    // CN is *.mariadb.org, but with subjectAltName present the CN must be ignored
+    verifyExceptionEqual(
+        "a.mariadb.org",
+        cert,
+        "DNS host \"a.mariadb.org\" doesn't correspond to "
+            + "SAN[{DNS:\"other.org\"},{DNS:\"www.other.org\"}]");
     verifyExceptionEqual(
         "a.other2.org",
         cert,
-        "DNS host \"a.other2.org\" doesn't correspond to certificate "
-            + "CN \"*.mariadb.org\" and SAN[{DNS:\"other.org\"},{DNS:\"www.other.org\"}]");
+        "DNS host \"a.other2.org\" doesn't correspond to "
+            + "SAN[{DNS:\"other.org\"},{DNS:\"www.other.org\"}]");
     HostnameVerifier.verify("other.org", cert, -1);
     verifyExceptionEqual(
         "a.other.org",
         cert,
-        "DNS host \"a.other.org\" doesn't correspond to certificate "
-            + "CN \"*.mariadb.org\" and SAN[{DNS:\"other.org\"},{DNS:\"www.other.org\"}]");
+        "DNS host \"a.other.org\" doesn't correspond to "
+            + "SAN[{DNS:\"other.org\"},{DNS:\"www.other.org\"}]");
     HostnameVerifier.verify("www.other.org", cert, -1);
   }
 
@@ -225,11 +230,7 @@ public class HostnameVerifierTest {
                 + "-----END CERTIFICATE-----\n");
     HostnameVerifier.verify("foo.com", cert, -1);
     verifyExceptionEqual(
-        "a.foo.com",
-        cert,
-        "CN not found in certificate principal \"EMAILADDRESS=juliusdavies@gmail.com, OU=test"
-            + " certificates, O=httpcomponents, L=Forest Hill, ST=Maryland, C=US\" and DNS host"
-            + " \"a.foo.com\" doesn't correspond to SAN[{DNS:\"foo.com\"}]");
+        "a.foo.com", cert, "DNS host \"a.foo.com\" doesn't correspond to SAN[{DNS:\"foo.com\"}]");
   }
 
   @Test
@@ -409,21 +410,21 @@ public class HostnameVerifierTest {
     verifyExceptionEqual(
         "local.host",
         cert,
-        "DNS host \"local.host\" doesn't correspond to certificate CN \"*.mariadb.org\" and"
+        "DNS host \"local.host\" doesn't correspond to"
             + " SAN[{DNS:\"localhost.localdomain\"},{DNS:\"localhost\"},{IP:\"127.0.0.1\"},{IP:\"2001:db8:3902:3468:0:0:0:443\"}]");
 
     HostnameVerifier.verify("127.0.0.1", cert, -1);
     verifyExceptionEqual(
         "127.0.0.2",
         cert,
-        "IPv4 host \"127.0.0.2\" doesn't correspond to certificate CN \"*.mariadb.org\" and"
+        "IPv4 host \"127.0.0.2\" doesn't correspond to"
             + " SAN[{DNS:\"localhost.localdomain\"},{DNS:\"localhost\"},{IP:\"127.0.0.1\"},{IP:\"2001:db8:3902:3468:0:0:0:443\"}]");
 
     HostnameVerifier.verify("2001:db8:3902:3468:0:0:0:443", cert, -1);
     verifyExceptionEqual(
         "2001:db8:1::",
         cert,
-        "IPv6 host \"2001:db8:1::\" doesn't correspond to certificate CN \"*.mariadb.org\" and"
+        "IPv6 host \"2001:db8:1::\" doesn't correspond to"
             + " SAN[{DNS:\"localhost.localdomain\"},{DNS:\"localhost\"},{IP:\"127.0.0.1\"},{IP:\"2001:db8:3902:3468:0:0:0:443\"}]");
   }
 
@@ -488,35 +489,35 @@ public class HostnameVerifierTest {
     verifyExceptionEqual(
         "other.org",
         cert,
-        "DNS host \"other.org\" doesn't correspond to certificate CN \"*.mariadb.org\" and"
+        "DNS host \"other.org\" doesn't correspond to"
             + " SAN[{DNS:\"*.other.org\"},{DNS:\"a*b.other2.com\"}]");
     HostnameVerifier.verify("www.other.org", cert, -1);
     verifyExceptionEqual(
         "other2.org",
         cert,
-        "DNS host \"other2.org\" doesn't correspond to certificate CN \"*.mariadb.org\" and"
+        "DNS host \"other2.org\" doesn't correspond to"
             + " SAN[{DNS:\"*.other.org\"},{DNS:\"a*b.other2.com\"}]");
     verifyExceptionEqual(
         "www.other2.org",
         cert,
-        "DNS host \"www.other2.org\" doesn't correspond to certificate CN \"*.mariadb.org\" and"
+        "DNS host \"www.other2.org\" doesn't correspond to"
             + " SAN[{DNS:\"*.other.org\"},{DNS:\"a*b.other2.com\"}]");
     HostnameVerifier.verify("ab.other2.com", cert, -1);
     HostnameVerifier.verify("axxxxb.other2.com", cert, -1);
     verifyExceptionEqual(
         "axxxxbc.other2.org",
         cert,
-        "DNS host \"axxxxbc.other2.org\" doesn't correspond to certificate CN \"*.mariadb.org\" and"
+        "DNS host \"axxxxbc.other2.org\" doesn't correspond to"
             + " SAN[{DNS:\"*.other.org\"},{DNS:\"a*b.other2.com\"}]");
     verifyExceptionEqual(
         "caxxxxb.other2.org",
         cert,
-        "DNS host \"caxxxxb.other2.org\" doesn't correspond to certificate CN \"*.mariadb.org\" and"
+        "DNS host \"caxxxxb.other2.org\" doesn't correspond to"
             + " SAN[{DNS:\"*.other.org\"},{DNS:\"a*b.other2.com\"}]");
     verifyExceptionEqual(
         "a.axxxxb.other2.org",
         cert,
-        "DNS host \"a.axxxxb.other2.org\" doesn't correspond to certificate CN \"*.mariadb.org\""
-            + " and SAN[{DNS:\"*.other.org\"},{DNS:\"a*b.other2.com\"}]");
+        "DNS host \"a.axxxxb.other2.org\" doesn't correspond to"
+            + " SAN[{DNS:\"*.other.org\"},{DNS:\"a*b.other2.com\"}]");
   }
 }

--- a/src/test/java/org/mariadb/jdbc/unit/client/HostnameVerifierTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/client/HostnameVerifierTest.java
@@ -178,7 +178,7 @@ public class HostnameVerifierTest {
         cert,
         "DNS host \"mariadb.org\" doesn't correspond to "
             + "SAN[{DNS:\"other.org\"},{DNS:\"www.other.org\"}]");
-    // CN is *.mariadb.org, but with subjectAltName present the CN must be ignored
+    // CN is *.mariadb.org, but with DNS subjectAltName entries present the CN must be ignored
     verifyExceptionEqual(
         "a.mariadb.org",
         cert,
@@ -426,6 +426,51 @@ public class HostnameVerifierTest {
         cert,
         "IPv6 host \"2001:db8:1::\" doesn't correspond to"
             + " SAN[{DNS:\"localhost.localdomain\"},{DNS:\"localhost\"},{IP:\"127.0.0.1\"},{IP:\"2001:db8:3902:3468:0:0:0:443\"}]");
+  }
+
+  @Test
+  public void subjectAltIpOnly() throws Exception {
+    // CN=*.mariadb.org, subjectAltName=IP:127.0.0.1
+    // openssl req -x509 -nodes -days 36500 -subj "/C=CN/ST=GD/L=SZ/O=Acme,Inc./CN=*.mariadb.org" \
+    //           -addext "subjectAltName=IP:127.0.0.1" -newkey rsa:2048 -keyout key.pem -out
+    // cert.pem
+    X509Certificate cert =
+        getCertificate(
+            "-----BEGIN CERTIFICATE-----\n"
+                + "MIIDmjCCAoKgAwIBAgIUdpzsnHZptuZ3TCQxe34P+d/oSnQwDQYJKoZIhvcNAQEL\n"
+                + "BQAwUzELMAkGA1UEBhMCQ04xCzAJBgNVBAgMAkdEMQswCQYDVQQHDAJTWjESMBAG\n"
+                + "A1UECgwJQWNtZSxJbmMuMRYwFAYDVQQDDA0qLm1hcmlhZGIub3JnMCAXDTI2MDcw\n"
+                + "NjEyMjYwN1oYDzIxMjYwNjEyMTIyNjA3WjBTMQswCQYDVQQGEwJDTjELMAkGA1UE\n"
+                + "CAwCR0QxCzAJBgNVBAcMAlNaMRIwEAYDVQQKDAlBY21lLEluYy4xFjAUBgNVBAMM\n"
+                + "DSoubWFyaWFkYi5vcmcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDn\n"
+                + "c0eQLYQOsor3vxb7E1FqjV3wVqYNUs5GHT/tvLqZE14QnXi8/vnIeWvJMxuyRUSz\n"
+                + "IpjUAUvpkMtJoaC4cs8OnwfYDYJbewJOyTcBBhehmosMjvHyo/FFI572jnaPXqtO\n"
+                + "XK3BdM13K7MYrJurK0kWiNV+cmrTzh91ta6FzYjGiWI5pXRmaazrVRBsWXMrpbKe\n"
+                + "OE40/2aBuFQzg9Ed+Wj4uBmQX2jF9Dh9q3bYxQgBOpsn6ElueF6rAVzZbIyVJsSk\n"
+                + "uJHvUEACLIpbhlF01tpheUNR3WLlbASVjk3p96AxrJ1HILeIch1v/yLgkK5Brq/N\n"
+                + "AtzeDywxUg7Hfa9+uaA7AgMBAAGjZDBiMB0GA1UdDgQWBBT7T4/UYzl3rXChFP6c\n"
+                + "29jUE0u9gjAfBgNVHSMEGDAWgBT7T4/UYzl3rXChFP6c29jUE0u9gjAPBgNVHRMB\n"
+                + "Af8EBTADAQH/MA8GA1UdEQQIMAaHBH8AAAEwDQYJKoZIhvcNAQELBQADggEBAKcR\n"
+                + "1E3XFHKChCcDmn3ZhVYwmEtVTyfFMX74S498ZSrW5AxXeHStpnBuezcbtBSWMbeB\n"
+                + "AP2a5AdWcs22GODRMEMucK+SCPg7i+8NLixdfkrUL5fJzwfnATgNz/yQg9xGOyeL\n"
+                + "bbjLK58MHSq5LknXgO7DjazKFDTx/nWx4HHUoNcuDU5KoWSCRzUbUj9AvvZezqcq\n"
+                + "gZ38UuRMum5IlwkWx+xtY5cTvh5vKyFcFfGeRNzeHy7vSWB8XZ/WYtGub7YVaeH/\n"
+                + "VmU05T/3op9TSWnOka+YPBFT7fzDgQb/pyO5PxUlirb0lL577ASiUdIndYprM0H4\n"
+                + "zGM1o2rkAUSUWbfpZjU=\n"
+                + "-----END CERTIFICATE-----\n");
+
+    // no dNSName SAN entry : DNS hosts still fall back to the CN
+    HostnameVerifier.verify("test.mariadb.org", cert, -1);
+    verifyExceptionEqual(
+        "test.org",
+        cert,
+        "DNS host \"test.org\" doesn't correspond to certificate CN \"*.mariadb.org\""
+            + " and SAN[{IP:\"127.0.0.1\"}]");
+
+    // iPAddress SAN entry present : CN is ignored for IP hosts
+    HostnameVerifier.verify("127.0.0.1", cert, -1);
+    verifyExceptionEqual(
+        "127.0.0.2", cert, "IPv4 host \"127.0.0.2\" doesn't correspond to SAN[{IP:\"127.0.0.1\"}]");
   }
 
   @Test


### PR DESCRIPTION
HostnameVerifier.verify falls back to the certificate CN even when the cert presents subjectAltName entries of the host's type:
- per RFC 6125 §6.4.4 and the OpenSSL/LibreSSL/BoringSSL default, the CN is only consulted when the certificate carries no SAN entry of the type matching the host (dNSName for DNS hosts, iPAddress for IP hosts)
- a cert with CN=*.mariadb.org and SAN=[DNS:other.org,DNS:www.other.org] is currently accepted for a.mariadb.org, a host its SAN does not cover
- gated the CN fallback on the absence of a matching-type SAN entry, so certs with only iPAddress entries still match DNS hosts on the CN and vice versa

Updated the verifier tests that encoded the old behavior and added coverage for an IP-only SAN cert (CONJ-1327).