### PR TITLE
match restrictedAuth plugin list exactly

### DIFF
--- a/src/main/java/org/mariadb/jdbc/plugin/authentication/AuthenticationPluginLoader.java
+++ b/src/main/java/org/mariadb/jdbc/plugin/authentication/AuthenticationPluginLoader.java
@@ -33,7 +33,7 @@ public final class AuthenticationPluginLoader {
 
     for (AuthenticationPluginFactory implClass : loader) {
       if (type.equals(implClass.type())) {
-        if (authList == null || Arrays.stream(authList).anyMatch(type::contains)) {
+        if (authList == null || Arrays.stream(authList).anyMatch(type::equals)) {
           return implClass;
         } else {
           throw new SQLException(

--- a/src/test/java/org/mariadb/jdbc/unit/plugin/AuthenticationPluginLoaderTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/plugin/AuthenticationPluginLoaderTest.java
@@ -26,4 +26,32 @@ class AuthenticationPluginLoaderTest extends Common {
         () -> AuthenticationPluginLoader.get("UNKNOWN", conf),
         "Client does not support authentication protocol requested by server");
   }
+
+  @Test
+  void restrictedAuthExactMatch() throws SQLException {
+    Configuration confExact =
+        Configuration.parse("jdbc:mariadb://localhost/?restrictedAuth=mysql_native_password");
+    assertTrue(
+        AuthenticationPluginLoader.get("mysql_native_password", confExact)
+            instanceof NativePasswordPluginFactory);
+
+    // a plugin requested by the server must be refused unless its type is exactly listed.
+    // substring entries ("mysql", "password") and empty list elements (leading/doubled comma)
+    // must not let the server pick mysql_clear_password, which sends the password in clear text.
+    for (String restricted :
+        new String[] {
+          "mysql_native_password",
+          "mysql",
+          "password",
+          ",mysql_native_password",
+          "mysql_native_password,,client_ed25519"
+        }) {
+      Configuration conf =
+          Configuration.parse("jdbc:mariadb://localhost/?restrictedAuth=" + restricted);
+      Common.assertThrowsContains(
+          SQLException.class,
+          () -> AuthenticationPluginLoader.get("mysql_clear_password", conf),
+          "doesn't permit requested plugin");
+    }
+  }
 }


### PR DESCRIPTION
restrictedAuth is meant to limit which auth plugins the server can pick, but AuthenticationPluginLoader matches each list entry with type.contains() rather than equality:
- an empty element from a leading or doubled comma makes contains("") true for every plugin, so the restriction is silently disabled
- a partial entry like "mysql" or "password" matches plugins that were never listed
- a server can then request mysql_clear_password and receive the account password in clear text

Switched the match to exact equality.