### PR TITLE
refuse local infile request when parameter value unavailable

### DIFF
--- a/src/main/java/org/mariadb/jdbc/message/ClientMessage.java
+++ b/src/main/java/org/mariadb/jdbc/message/ClientMessage.java
@@ -75,7 +75,8 @@ public interface ClientMessage {
         if (paramString != null) {
           return paramString.equals("'" + fileName.replace("\\", "\\\\") + "'");
         }
-        return true;
+        // parameter value can't be rendered to compare against the requested file, refuse
+        return false;
       }
     }
     return false;

--- a/src/test/java/org/mariadb/jdbc/unit/message/ClientMessageTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/message/ClientMessageTest.java
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (c) 2012-2014 Monty Program Ab
-// Copyright (c) 2015-2025 MariaDB Corporation Ab
+// Copyright (c) 2015-2026 MariaDB Corporation Ab
 package org.mariadb.jdbc.unit.message;
 
+import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.client.Context;
+import org.mariadb.jdbc.client.socket.Writer;
+import org.mariadb.jdbc.client.util.Parameter;
+import org.mariadb.jdbc.client.util.Parameters;
 import org.mariadb.jdbc.message.ClientMessage;
 
 public class ClientMessageTest {
@@ -28,5 +33,71 @@ public class ClientMessageTest {
 
     // unrelated file refused
     Assertions.assertFalse(ClientMessage.validateLocalFileName(sql, null, "/etc/passwd", null));
+  }
+
+  @Test
+  public void validateLocalFileNameUnknownParamRefused() {
+    // parameterized LOAD DATA LOCAL INFILE where the bound parameter can't be rendered to a
+    // literal (bestEffortStringValue returns null, e.g. a streaming parameter). The requested
+    // file can't be matched against the query, so the server request must be refused.
+    String sql = "LOAD DATA LOCAL INFILE ?";
+    Parameters params = singleParam(unrenderableParameter());
+    Assertions.assertFalse(ClientMessage.validateLocalFileName(sql, params, "/etc/passwd", null));
+  }
+
+  private static Parameter unrenderableParameter() {
+    return new Parameter() {
+      public void encodeText(Writer encoder, Context context) throws IOException {}
+
+      public int getApproximateTextProtocolLength() {
+        return -1;
+      }
+
+      public void encodeBinary(Writer encoder, Context context) {}
+
+      public void encodeLongData(Writer encoder) {}
+
+      public byte[] encodeData() {
+        return new byte[0];
+      }
+
+      public boolean canEncodeLongData() {
+        return true;
+      }
+
+      public int getBinaryEncodeType() {
+        return 0;
+      }
+
+      public boolean isNull() {
+        return false;
+      }
+
+      public String bestEffortStringValue(Context context) {
+        return null;
+      }
+    };
+  }
+
+  private static Parameters singleParam(Parameter parameter) {
+    return new Parameters() {
+      public Parameter get(int index) {
+        return parameter;
+      }
+
+      public boolean containsKey(int index) {
+        return index == 0;
+      }
+
+      public void set(int index, Parameter element) {}
+
+      public int size() {
+        return 1;
+      }
+
+      public Parameters clone() {
+        return this;
+      }
+    };
   }
 }


### PR DESCRIPTION
validateLocalFileName accepts any server-requested file when the bound parameter can't be rendered to a literal:
- in the parameterized branch, a null bestEffortStringValue falls through to `return true`, authorizing whatever file the server asked for
- bestEffortStringValue returns null when the value can't be encoded (its contract returns null for streaming parameters), so a malicious or proxy server can make the client read and send an arbitrary local file
- fail closed instead, so a request that can't be matched against the query is refused

regression test added alongside the existing case-sensitivity one.