### PR TITLE
validate trustStore chain instead of deferring identity

### DIFF
--- a/src/main/java/org/mariadb/jdbc/plugin/tls/main/DefaultTlsSocketPlugin.java
+++ b/src/main/java/org/mariadb/jdbc/plugin/tls/main/DefaultTlsSocketPlugin.java
@@ -212,7 +212,7 @@ public class DefaultTlsSocketPlugin implements TlsSocketPlugin {
           tmf.init(ks);
           for (TrustManager tm : tmf.getTrustManagers()) {
             if (tm instanceof X509TrustManager) {
-              return new CachedTrust((X509TrustManager) tm, true);
+              return new CachedTrust((X509TrustManager) tm, false);
             }
           }
         } catch (GeneralSecurityException generalSecurityEx) {

--- a/src/test/java/org/mariadb/jdbc/unit/plugin/DefaultTlsSocketPluginTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/plugin/DefaultTlsSocketPluginTest.java
@@ -3,14 +3,20 @@
 // Copyright (c) 2015-2026 MariaDB Corporation Ab
 package org.mariadb.jdbc.unit.plugin;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.sql.SQLException;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -86,6 +92,36 @@ class DefaultTlsSocketPluginTest {
 
     // serverSslCert validates normally (no deferred identity), so the cached base is returned as-is
     TrustManager first = firstTrustManager(plugin, conf);
+    assertSame(
+        first, firstTrustManager(plugin, conf), "same configuration must reuse the cached base");
+  }
+
+  @Test
+  void trustStoreValidatesNormally(@TempDir Path tmp) throws Exception {
+    // A user-provided trustStore is explicit trust material, exactly like serverSslCert, so it must
+    // validate the chain normally and not fall on the deferred-identity (system-trust-store) path.
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    X509Certificate ca =
+        (X509Certificate)
+            cf.generateCertificate(new ByteArrayInputStream(PEM.getBytes(StandardCharsets.UTF_8)));
+    KeyStore ks = KeyStore.getInstance("PKCS12");
+    ks.load(null, null);
+    ks.setCertificateEntry("ca", ca);
+    Path store = tmp.resolve("truststore.p12");
+    try (OutputStream os = Files.newOutputStream(store)) {
+      ks.store(os, "changeit".toCharArray());
+    }
+
+    DefaultTlsSocketPlugin plugin = new DefaultTlsSocketPlugin();
+    Configuration conf =
+        Configuration.parse(
+            "jdbc:mariadb://localhost:3306/test?sslMode=verify_ca&trustStoreType=PKCS12&trustStorePassword=changeit&trustStore="
+                + store);
+
+    TrustManager first = firstTrustManager(plugin, conf);
+    assertFalse(
+        first instanceof MariaDbX509DeferredIdentityTrustManager,
+        "an explicit trustStore must validate the certificate chain, not defer identity");
     assertSame(
         first, firstTrustManager(plugin, conf), "same configuration must reuse the cached base");
   }


### PR DESCRIPTION
An explicit trustStore is put on the lenient deferred-identity path:
- buildTrust wraps the trustStore branch with deferIdentity=true; the equivalent serverSslCert branch uses false
- a server certificate that does not chain to the pinned trustStore is then accepted at the handshake, and under VERIFY_FULL the hostname check is skipped since certFingerprint is set
- both serverSslCert and trustStore are user-provided trust anchors and should validate identically; only the no-explicit-material system fallback is meant to defer

Set the trustStore branch to strict validation, matching serverSslCert.
