### PR TITLE
mask sensitive nonMappedOptions when serializing connection url

### DIFF
--- a/src/main/java/org/mariadb/jdbc/Configuration.java
+++ b/src/main/java/org/mariadb/jdbc/Configuration.java
@@ -1047,7 +1047,9 @@ public class Configuration {
             entry ->
                 new AbstractMap.SimpleEntry<>(
                     entry.getKey().toString(),
-                    entry.getValue() != null ? entry.getValue().toString() : ""))
+                    isSensitiveOption(entry.getKey().toString())
+                        ? "***"
+                        : (entry.getValue() != null ? entry.getValue().toString() : "")))
         .sorted(Map.Entry.comparingByKey())
         .forEach(
             entry ->
@@ -1335,8 +1337,24 @@ public class Configuration {
 
   private static void appendPropertiesParameter(ParameterAppender appender, Properties props) {
     for (Object key : props.keySet()) {
-      appender.appendParameter(key.toString(), props.get(key).toString());
+      String keyName = key.toString();
+      appender.appendParameter(
+          keyName, isSensitiveOption(keyName) ? "***" : props.get(key).toString());
     }
+  }
+
+  /**
+   * A credential that has no dedicated field is kept in nonMappedOptions, e.g. the AWS IAM {@code
+   * secretKey} or the PAM {@code password2}/{@code password3} steps. Mask those values the same way
+   * {@link #SECURE_FIELDS} masks the declared password fields, so a serialized url does not expose
+   * them.
+   *
+   * @param key option name
+   * @return true if the option value must be redacted
+   */
+  private static boolean isSensitiveOption(String key) {
+    String lower = key.toLowerCase(Locale.ROOT);
+    return lower.contains("password") || lower.contains("secret");
   }
 
   private static void appendCatalogTermParameter(

--- a/src/test/java/org/mariadb/jdbc/unit/util/ConfigurationTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/util/ConfigurationTest.java
@@ -1117,6 +1117,26 @@ public class ConfigurationTest {
                     + " * allowLocalInfile : true"));
   }
 
+  @Test
+  public void nonMappedSensitiveOptionsMasked() throws SQLException {
+    // secretKey (AWS IAM) and password2 (PAM step) have no dedicated field, so they land in
+    // nonMappedOptions. The serialized url must mask them like the primary password.
+    String url =
+        "jdbc:mariadb://localhost/test?user=me&password=myPass&secretKey=SECRETVAL&password2=PAMVAL";
+    Configuration conf = Configuration.parse(url);
+
+    String built = conf.initialUrl();
+    assertFalse(built.contains("SECRETVAL"), built);
+    assertFalse(built.contains("PAMVAL"), built);
+    assertTrue(built.contains("password=***"), built);
+    assertTrue(built.contains("secretKey=***"), built);
+    assertTrue(built.contains("password2=***"), built);
+
+    String conf2 = Configuration.toConf(url);
+    assertFalse(conf2.contains("SECRETVAL"), conf2);
+    assertFalse(conf2.contains("PAMVAL"), conf2);
+  }
+
   private String normalizeConfigurationString(String configString) {
     String[] lines = configString.split("\n");
     StringBuilder newConfig = new StringBuilder();


### PR DESCRIPTION
the connection url serialization redacts the declared password fields but leaves credentials kept in nonMappedOptions in clear text:
- getUrl() / DatabaseMetaData.getURL() (buildUrl, appendPropertiesParameter) print nonMapped options verbatim, so AWS IAM secretKey and PAM password2/password3 leak while password already shows ***
- toConf()'s "Unknown options" block (appendUnknownOptions) has the same gap
these urls are commonly logged by pools, orms and monitoring. mask nonMapped options whose name contains password or secret, matching the existing SECURE_FIELDS redaction.