### PR TITLE
cap length-encoded field length before narrowing to int in row decoders

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/result/rowdecoder/BinaryRowDecoder.java
+++ b/src/main/java/org/mariadb/jdbc/client/result/rowdecoder/BinaryRowDecoder.java
@@ -180,7 +180,8 @@ public class BinaryRowDecoder implements RowDecoder {
       final int maxIndex,
       final ReadableByteBuf rowBuf,
       final byte[] nullBitmap,
-      final ColumnDecoder[] metadataList) {
+      final ColumnDecoder[] metadataList)
+      throws SQLException {
 
     if (fieldIndex.get() >= newIndex) {
       fieldIndex.set(0);
@@ -267,7 +268,11 @@ public class BinaryRowDecoder implements RowDecoder {
 
           case (byte) 254:
             // length is encoded on 9 bytes (0xfe header + 8 bytes indicating length)
-            return (int) rowBuf.readLong();
+            long fieldLength = rowBuf.readLong();
+            if (fieldLength < 0 || fieldLength > Integer.MAX_VALUE) {
+              throw new SQLException("Invalid length-encoded field length " + fieldLength);
+            }
+            return (int) fieldLength;
           default:
             return len & 0xff;
         }

--- a/src/main/java/org/mariadb/jdbc/client/result/rowdecoder/RowDecoder.java
+++ b/src/main/java/org/mariadb/jdbc/client/result/rowdecoder/RowDecoder.java
@@ -36,6 +36,7 @@ public interface RowDecoder {
    * @param nullBitmap null bitmap
    * @param metadataList metadata list
    * @return new index to read data
+   * @throws SQLException if the field length is not a valid value
    */
   int setPosition(
       int newIndex,
@@ -43,7 +44,8 @@ public interface RowDecoder {
       int maxIndex,
       ReadableByteBuf rowBuf,
       byte[] nullBitmap,
-      ColumnDecoder[] metadataList);
+      ColumnDecoder[] metadataList)
+      throws SQLException;
 
   /**
    * Decode data according to data type.

--- a/src/main/java/org/mariadb/jdbc/client/result/rowdecoder/TextRowDecoder.java
+++ b/src/main/java/org/mariadb/jdbc/client/result/rowdecoder/TextRowDecoder.java
@@ -167,7 +167,8 @@ public class TextRowDecoder implements RowDecoder {
       final int maxIndex,
       final ReadableByteBuf rowBuf,
       final byte[] nullBitmap,
-      final ColumnDecoder[] metadataList) {
+      final ColumnDecoder[] metadataList)
+      throws SQLException {
     if (fieldIndex.get() >= newIndex) {
       fieldIndex.set(0);
       rowBuf.pos(0);
@@ -189,9 +190,11 @@ public class TextRowDecoder implements RowDecoder {
       case (byte) 253:
         return rowBuf.readUnsignedMedium();
       case (byte) 254:
-        int fieldLength = (int) rowBuf.readUnsignedInt();
-        rowBuf.skip(4);
-        return fieldLength;
+        long fieldLength = rowBuf.readLong();
+        if (fieldLength < 0 || fieldLength > Integer.MAX_VALUE) {
+          throw new SQLException("Invalid length-encoded field length " + fieldLength);
+        }
+        return (int) fieldLength;
       default:
         return len & 0xff;
     }

--- a/src/test/java/org/mariadb/jdbc/unit/client/result/RowDecoderLengthTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/client/result/RowDecoderLengthTest.java
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (c) 2012-2014 Monty Program Ab
+// Copyright (c) 2015-2026 MariaDB Corporation Ab
+package org.mariadb.jdbc.unit.client.result;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.sql.SQLException;
+import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.client.ColumnDecoder;
+import org.mariadb.jdbc.client.DataType;
+import org.mariadb.jdbc.client.ReadableByteBuf;
+import org.mariadb.jdbc.client.result.rowdecoder.BinaryRowDecoder;
+import org.mariadb.jdbc.client.result.rowdecoder.TextRowDecoder;
+import org.mariadb.jdbc.client.util.MutableInt;
+
+public class RowDecoderLengthTest {
+
+  private static final ColumnDecoder[] META = {
+    ColumnDecoder.create("db", "col", DataType.VARCHAR, 0)
+  };
+
+  @Test
+  public void textOversizeLengthEncodedFieldRejected() {
+    // a 0xFE length-encoded field whose low 32 bits are 0xFFFFFFFF used to narrow to -1
+    // (NULL_LENGTH), silently turning a non-null value into SQL NULL
+    byte[] row = {(byte) 254, -1, -1, -1, -1, 0, 0, 0, 0};
+    ReadableByteBuf buf = new ReadableByteBuf(row, row.length);
+    assertThrows(
+        SQLException.class,
+        () ->
+            new TextRowDecoder()
+                .setPosition(0, new MutableInt(), 1, buf, new byte[0], META));
+  }
+
+  @Test
+  public void textValidLengthEncodedFieldReturned() throws SQLException {
+    byte[] row = {(byte) 254, 100, 0, 0, 0, 0, 0, 0, 0};
+    ReadableByteBuf buf = new ReadableByteBuf(row, row.length);
+    assertEquals(
+        100, new TextRowDecoder().setPosition(0, new MutableInt(), 1, buf, new byte[0], META));
+  }
+
+  @Test
+  public void binaryOversizeLengthEncodedFieldRejected() {
+    // header + null-bitmap(1 byte, field not null) + 0xFE + 8-byte length
+    byte[] row = {0, 0, (byte) 254, -1, -1, -1, -1, 0, 0, 0, 0};
+    ReadableByteBuf buf = new ReadableByteBuf(row, row.length);
+    assertThrows(
+        SQLException.class,
+        () ->
+            new BinaryRowDecoder()
+                .setPosition(0, new MutableInt(), 1, buf, new byte[1], META));
+  }
+
+  @Test
+  public void binaryValidLengthEncodedFieldReturned() throws SQLException {
+    byte[] row = {0, 0, (byte) 254, 100, 0, 0, 0, 0, 0, 0, 0};
+    ReadableByteBuf buf = new ReadableByteBuf(row, row.length);
+    assertEquals(
+        100, new BinaryRowDecoder().setPosition(0, new MutableInt(), 1, buf, new byte[1], META));
+  }
+}


### PR DESCRIPTION
Two row decoders narrow a length-encoded field length to int with an unchecked cast:
- TextRowDecoder.setPosition keeps only the low 32 bits, so a server length ending 0xFFFFFFFF becomes -1, which is NULL_LENGTH, and a non-null column reads back as SQL NULL
- BinaryRowDecoder.setPosition has the same cast on the 8-byte form; other high-bit lengths become a negative int that reaches new byte[] in the codecs
Read the full value and reject anything outside 0..Integer.MAX_VALUE.