### PR TITLE
escape identifiers in updatable result set generated sql

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/result/UpdatableResult.java
+++ b/src/main/java/org/mariadb/jdbc/client/result/UpdatableResult.java
@@ -133,7 +133,8 @@ public class UpdatableResult extends CompleteResult {
         statement
             .getConnection()
             .createStatement()
-            .executeQuery("SHOW COLUMNS FROM `" + database + "`.`" + table + "`");
+            .executeQuery(
+                "SHOW COLUMNS FROM " + quoteIdentifier(database) + "." + quoteIdentifier(table));
     List<String> primaryColumns = new ArrayList<>();
     while (rs.next()) {
       if ("PRI".equals(rs.getString("Key"))) {
@@ -498,13 +499,26 @@ public class UpdatableResult extends CompleteResult {
   }
 
   /**
+   * Wrap a schema, table or column identifier in backticks, doubling any backtick it contains so a
+   * name that includes a backtick cannot terminate the quoting.
+   *
+   * @param identifier identifier
+   * @return quoted identifier
+   */
+  private static String quoteIdentifier(String identifier) {
+    return "`" + identifier.replace("`", "``") + "`";
+  }
+
+  /**
    * Build insert query
    *
    * @return insert sql
    * @throws SQLException exception
    */
   private String buildInsertQuery() throws SQLException {
-    StringBuilder insertSql = new StringBuilder("INSERT `" + database + "`.`" + table + "` ( ");
+    StringBuilder insertSql =
+        new StringBuilder(
+            "INSERT " + quoteIdentifier(database) + "." + quoteIdentifier(table) + " ( ");
     StringBuilder valueClause = new StringBuilder();
     StringBuilder returningClause = new StringBuilder();
 
@@ -516,7 +530,7 @@ public class UpdatableResult extends CompleteResult {
       if (pos != 0) {
         returningClause.append(", ");
       }
-      returningClause.append("`").append(colInfo.getColumnName()).append("`");
+      returningClause.append(quoteIdentifier(colInfo.getColumnName()));
 
       org.mariadb.jdbc.client.util.Parameter param =
           parameters.size() > pos ? parameters.get(pos) : null;
@@ -525,7 +539,7 @@ public class UpdatableResult extends CompleteResult {
           insertSql.append(",");
           valueClause.append(", ");
         }
-        insertSql.append("`").append(colInfo.getColumnName()).append("`");
+        insertSql.append(quoteIdentifier(colInfo.getColumnName()));
         valueClause.append("?");
         firstParam = false;
       } else {
@@ -556,7 +570,7 @@ public class UpdatableResult extends CompleteResult {
             valueClause.append(", ");
           }
           firstParam = false;
-          insertSql.append("`").append(colInfo.getColumnName()).append("`");
+          insertSql.append(quoteIdentifier(colInfo.getColumnName()));
           valueClause.append("?");
         }
       }
@@ -581,22 +595,21 @@ public class UpdatableResult extends CompleteResult {
       if (pos != 0) {
         selectSql.append(",");
       }
-      selectSql.append("`").append(colInfo.getColumnName()).append("`");
+      selectSql.append(quoteIdentifier(colInfo.getColumnName()));
 
       if (Arrays.asList(primaryCols).contains(colInfo.getColumnName())) {
         if (!firstPrimary) {
           whereClause.append("AND ");
         }
         firstPrimary = false;
-        whereClause.append("`").append(colInfo.getColumnName()).append("` = ? ");
+        whereClause.append(quoteIdentifier(colInfo.getColumnName())).append(" = ? ");
       }
     }
     selectSql
-        .append(" FROM `")
-        .append(database)
-        .append("`.`")
-        .append(table)
-        .append("`")
+        .append(" FROM ")
+        .append(quoteIdentifier(database))
+        .append(".")
+        .append(quoteIdentifier(table))
         .append(whereClause);
     return selectSql.toString();
   }
@@ -639,7 +652,9 @@ public class UpdatableResult extends CompleteResult {
   }
 
   private String updateQuery() {
-    StringBuilder updateSql = new StringBuilder("UPDATE `" + database + "`.`" + table + "` SET ");
+    StringBuilder updateSql =
+        new StringBuilder(
+            "UPDATE " + quoteIdentifier(database) + "." + quoteIdentifier(table) + " SET ");
     StringBuilder whereClause = new StringBuilder(" WHERE ");
 
     boolean firstUpdate = true;
@@ -649,7 +664,7 @@ public class UpdatableResult extends CompleteResult {
       if (pos != 0) {
         whereClause.append("AND ");
       }
-      whereClause.append("`").append(key).append("` = ? ");
+      whereClause.append(quoteIdentifier(key)).append(" = ? ");
     }
 
     for (int pos = 0; pos < metadataList.length; pos++) {
@@ -660,7 +675,7 @@ public class UpdatableResult extends CompleteResult {
           updateSql.append(",");
         }
         firstUpdate = false;
-        updateSql.append("`").append(colInfo.getColumnName()).append("` = ? ");
+        updateSql.append(quoteIdentifier(colInfo.getColumnName())).append(" = ? ");
       }
     }
     if (firstUpdate) return null;
@@ -742,7 +757,8 @@ public class UpdatableResult extends CompleteResult {
 
     // Create query with WHERE clause contain primary field.
     StringBuilder deleteSql =
-        new StringBuilder("DELETE FROM `" + database + "`.`" + table + "` WHERE ");
+        new StringBuilder(
+            "DELETE FROM " + quoteIdentifier(database) + "." + quoteIdentifier(table) + " WHERE ");
     boolean firstPrimary = true;
     for (Column colInfo : metadataList) {
       if (Arrays.asList(primaryCols).contains(colInfo.getColumnName())) {
@@ -750,7 +766,7 @@ public class UpdatableResult extends CompleteResult {
           deleteSql.append("AND ");
         }
         firstPrimary = false;
-        deleteSql.append("`").append(colInfo.getColumnName()).append("` = ? ");
+        deleteSql.append(quoteIdentifier(colInfo.getColumnName())).append(" = ? ");
       }
     }
 

--- a/src/test/java/org/mariadb/jdbc/integration/UpdateResultSetTest.java
+++ b/src/test/java/org/mariadb/jdbc/integration/UpdateResultSetTest.java
@@ -31,6 +31,7 @@ public class UpdateResultSetTest extends Common {
     stmt.execute("DROP TABLE IF EXISTS `testDefaultUUID`");
     stmt.execute("DROP TABLE IF EXISTS `test_update_max`");
     stmt.execute("DROP TABLE IF EXISTS `testAutoIncrement`");
+    stmt.execute("DROP TABLE IF EXISTS `testBacktickCol`");
   }
 
   @BeforeAll
@@ -215,6 +216,45 @@ public class UpdateResultSetTest extends Common {
     assertEquals("0-1", rs.getString(2));
     assertFalse(rs.next());
     sharedConn.rollback();
+  }
+
+  @Test
+  public void updatableResultBacktickIdentifier() throws SQLException {
+    // a column whose name contains a backtick (valid in MariaDB, and reachable through a query
+    // alias) must be escaped when the updatable result-set builds its INSERT/UPDATE/SELECT
+    // statements. Otherwise the backtick terminates the identifier quoting and arbitrary SQL is
+    // injected into the driver-generated statement.
+    Statement stmt = sharedConn.createStatement();
+    stmt.execute("DROP TABLE IF EXISTS `testBacktickCol`");
+    stmt.execute(
+        "CREATE TABLE `testBacktickCol`(`id` INT NOT NULL AUTO_INCREMENT,`a``b` VARCHAR(50) NULL,"
+            + "PRIMARY KEY (`id`))");
+    stmt.execute("START TRANSACTION"); // if MAXSCALE ensure using WRITER
+    stmt.executeUpdate("INSERT INTO `testBacktickCol`(`a``b`) values ('one')");
+
+    try (PreparedStatement prep =
+        sharedConn.prepareStatement(
+            "SELECT `id`, `a``b` FROM `testBacktickCol`",
+            ResultSet.TYPE_FORWARD_ONLY,
+            ResultSet.CONCUR_UPDATABLE)) {
+      ResultSet rs = prep.executeQuery();
+      assertTrue(rs.next());
+      rs.updateString(2, "two");
+      rs.updateRow();
+
+      rs.moveToInsertRow();
+      rs.updateString(2, "three");
+      rs.insertRow();
+    }
+
+    ResultSet rs = stmt.executeQuery("SELECT `a``b` FROM `testBacktickCol` ORDER BY `id`");
+    assertTrue(rs.next());
+    assertEquals("two", rs.getString(1));
+    assertTrue(rs.next());
+    assertEquals("three", rs.getString(1));
+    assertFalse(rs.next());
+    sharedConn.rollback();
+    stmt.execute("DROP TABLE IF EXISTS `testBacktickCol`");
   }
 
   @Test


### PR DESCRIPTION
**Identifiers not escaped in updatable result set queries**
The insert/update/delete/select builders in `UpdatableResult` wrap the schema, table and column names in backticks without doubling backticks inside the name, so a name containing a backtick (allowed by MariaDB, and reachable through a result-set column alias) closes the identifier early and injects SQL into the generated statement. Routed those identifiers through a helper that doubles backticks, matching `enquoteIdentifier` and the savepoint / `CREATE DATABASE` paths; behavior for backtick-free names is unchanged.