### PR TITLE
[CONJ-1336] strip trailing dot from hostname before SNI and hostname …

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/impl/StandardClient.java
+++ b/src/main/java/org/mariadb/jdbc/client/impl/StandardClient.java
@@ -284,7 +284,7 @@ public class StandardClient implements Client, AutoCloseable {
     // Set SNI hostname
     if (this.hostAddress != null && !IPUtility.isInetAddress(this.hostAddress.host)) {
       SSLParameters params = sslSocket.getSSLParameters();
-      SNIHostName serverName = new SNIHostName(this.hostAddress.host);
+      SNIHostName serverName = new SNIHostName(IPUtility.stripTrailingDot(this.hostAddress.host));
       params.setServerNames(Collections.singletonList(serverName));
       sslSocket.setSSLParameters(params);
     }
@@ -304,7 +304,10 @@ public class StandardClient implements Client, AutoCloseable {
   private void verifyHostname(SSLSocket sslSocket, TlsSocketPlugin socketPlugin)
       throws SQLException {
     try {
-      socketPlugin.verify(hostAddress.host, sslSocket.getSession(), context.getThreadId());
+      socketPlugin.verify(
+          IPUtility.stripTrailingDot(hostAddress.host),
+          sslSocket.getSession(),
+          context.getThreadId());
     } catch (SSLException ex) {
       throw context
           .getExceptionFactory()

--- a/src/main/java/org/mariadb/jdbc/util/IPUtility.java
+++ b/src/main/java/org/mariadb/jdbc/util/IPUtility.java
@@ -79,4 +79,12 @@ public class IPUtility {
       return false;
     }
   }
+
+  // RFC 6066 section 3 prohibits trailing dots in SNI hostnames
+  public static String stripTrailingDot(String host) {
+    if (host != null && host.endsWith(".")) {
+      return host.substring(0, host.length() - 1);
+    }
+    return host;
+  }
 }

--- a/src/test/java/org/mariadb/jdbc/unit/client/SniHostnameTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/client/SniHostnameTest.java
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (c) 2012-2014 Monty Program Ab
+// Copyright (c) 2015-2026 MariaDB Corporation Ab
+package org.mariadb.jdbc.unit.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.net.ssl.SNIHostName;
+import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.util.IPUtility;
+
+public class SniHostnameTest {
+
+  @Test
+  public void normalHostname() {
+    String host = IPUtility.stripTrailingDot("mariadb.database.svc.cluster.local");
+    SNIHostName sni = new SNIHostName(host);
+    assertEquals("mariadb.database.svc.cluster.local", sni.getAsciiName());
+  }
+
+  @Test
+  public void trailingDotFqdn() {
+    String host = IPUtility.stripTrailingDot("mariadb.database.svc.cluster.local.");
+    SNIHostName sni = new SNIHostName(host);
+    assertEquals("mariadb.database.svc.cluster.local", sni.getAsciiName());
+  }
+
+  @Test
+  public void trailingDotSimpleHostname() {
+    String host = IPUtility.stripTrailingDot("dbhost.");
+    SNIHostName sni = new SNIHostName(host);
+    assertEquals("dbhost", sni.getAsciiName());
+  }
+
+  @Test
+  public void rawTrailingDotRejected() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new SNIHostName("mariadb.database.svc.cluster.local."));
+  }
+
+  @Test
+  public void hostnameWithoutDotUnchanged() {
+    assertEquals("localhost", IPUtility.stripTrailingDot("localhost"));
+  }
+
+  @Test
+  public void nullHostUnchanged() {
+    assertNull(IPUtility.stripTrailingDot(null));
+  }
+
+  @Test
+  public void trailingDotPreservedForDns() throws Exception {
+    org.mariadb.jdbc.Configuration conf =
+        org.mariadb.jdbc.Configuration.parse(
+            "jdbc:mariadb://mariadb.database.svc.cluster.local.:3306/test");
+    assertEquals("mariadb.database.svc.cluster.local.", conf.addresses().get(0).host);
+  }
+}


### PR DESCRIPTION
…verification

Strip trailing dot from hostname before creating `SNIHostName` and before hostname verification. Although trailing-dot FQDNs are valid in DNS, `SNIHostName` should reject them per RFC 6066 section 3.

This is related to: https://github.com/keycloak/keycloak/issues/51030
